### PR TITLE
Feat: [FLOW CONTROL]: KV Cache Saturation V1

### DIFF
--- a/configs/scheduler_config.yaml
+++ b/configs/scheduler_config.yaml
@@ -22,13 +22,15 @@ data:
     profile_handler:
       type: single_profile
     profiles:
-      epp_backpressure:
+      without_router:
+        flow_control:
+          use_token_budget: true
+          kv_budget_tokens: 727936
+          default_osl: 1024
+          drip_threshold_kv: 0.2
+          drip_interval_s: 2.0
         scorers:
-          - type: waiting_queue
+          - type: round_robin
             weight: 1.0
-          - type: running_queue
-            weight: 1.0
-          - type: kv_cache
-            weight: 2.0
         picker:
           type: max_score

--- a/configs/scheduler_config.yaml
+++ b/configs/scheduler_config.yaml
@@ -22,7 +22,7 @@ data:
     profile_handler:
       type: single_profile
     profiles:
-      without_router:
+      router_with_token_budget_and_drip:
         flow_control:
           use_token_budget: true
           kv_budget_tokens: 727936

--- a/configs/scheduler_config.yaml
+++ b/configs/scheduler_config.yaml
@@ -25,7 +25,6 @@ data:
       router_with_token_budget_and_drip:
         flow_control:
           use_token_budget: true
-          kv_budget_tokens: 727936
           default_osl: 1024
           drip_threshold_kv: 0.2
           drip_interval_s: 2.0

--- a/datalayer/rayserve/engine.py
+++ b/datalayer/rayserve/engine.py
@@ -45,6 +45,9 @@ class DirectKVCacheLogger(StatLoggerBase):
                 scheduler_stats, "num_running_reqs", 0
             )
 
+        if self.target_dict is not None and iteration_stats is not None:
+            self.target_dict["num_preempted"] += getattr(iteration_stats, "num_preempted_reqs", 0)
+
 
 class MetricsAwareVLLMEngine(VLLMEngine):
     def _start_async_llm_engine(
@@ -53,7 +56,12 @@ class MetricsAwareVLLMEngine(VLLMEngine):
         engine_config: object,
         pg: object,
     ) -> object:
-        self.live_metrics = {"kv": 0.0, "num_waiting_reqs": 0, "num_running_reqs": 0}
+        self.live_metrics = {
+            "kv": 0.0,
+            "num_waiting_reqs": 0,
+            "num_running_reqs": 0,
+            "num_preempted": 0,
+        }
 
         # vLLM expects a StatLoggerFactory, so use a closure that attaches
         # our metrics dict to each logger instance.
@@ -85,6 +93,7 @@ class MetricsAwareVLLMEngine(VLLMEngine):
             "kv": self.live_metrics.get("kv", 0.0),
             "num_waiting_reqs": self.live_metrics.get("num_waiting_reqs", 0),
             "num_running_reqs": self.live_metrics.get("num_running_reqs", 0),
+            "num_preempted": self.live_metrics.get("num_preempted", 0),
         }
 
         if not hasattr(self, "_total_kv_tokens"):

--- a/datalayer/rayserve/engine.py
+++ b/datalayer/rayserve/engine.py
@@ -22,7 +22,7 @@ from vllm.v1.metrics.loggers import StatLoggerBase  # type: ignore[import-not-fo
 class DirectKVCacheLogger(StatLoggerBase):
     def __init__(self, vllm_config: object, engine_idx: int = 0) -> None:
         # The factory signature mandates these arguments.
-        self.target_dict: dict[str, object] | None = None
+        self.target_dict: dict[str, float | int] | None = None
 
     def log(self) -> None:
         pass
@@ -89,7 +89,7 @@ class MetricsAwareVLLMEngine(VLLMEngine):
 
     def record_routing_stats(self) -> dict[str, object]:
         # Ray natively expects this to return a dictionary
-        res = {
+        res: dict[str, object] = {
             "kv": self.live_metrics.get("kv", 0.0),
             "num_waiting_reqs": self.live_metrics.get("num_waiting_reqs", 0),
             "num_running_reqs": self.live_metrics.get("num_running_reqs", 0),

--- a/datalayer/rayserve/engine.py
+++ b/datalayer/rayserve/engine.py
@@ -81,11 +81,28 @@ class MetricsAwareVLLMEngine(VLLMEngine):
 
     def record_routing_stats(self) -> dict[str, object]:
         # Ray natively expects this to return a dictionary
-        return {
+        res = {
             "kv": self.live_metrics.get("kv", 0.0),
             "num_waiting_reqs": self.live_metrics.get("num_waiting_reqs", 0),
             "num_running_reqs": self.live_metrics.get("num_running_reqs", 0),
         }
+
+        if not hasattr(self, "_total_kv_tokens"):
+            try:
+                engine = self._engine_client
+                vllm_config = getattr(engine, "vllm_config", None)
+                if vllm_config:
+                    num_blocks = vllm_config.cache_config.num_gpu_blocks
+                    block_size = vllm_config.cache_config.block_size
+                    self._total_kv_tokens = num_blocks * block_size
+                else:
+                    self._total_kv_tokens = -1
+            except Exception as e:
+                print(f"[METRICS ERROR] Failed to extract KV Cache size: {e}")
+                self._total_kv_tokens = -1
+
+        res["kv_cache_size"] = self._total_kv_tokens
+        return res
 
 
 class MetricsAwareLLMServer(LLMServer):

--- a/datalayer/rayserve/engine.py
+++ b/datalayer/rayserve/engine.py
@@ -106,7 +106,7 @@ class MetricsAwareVLLMEngine(VLLMEngine):
                     self._total_kv_tokens = num_blocks * block_size
                 else:
                     self._total_kv_tokens = -1
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 print(f"[METRICS ERROR] Failed to extract KV Cache size: {e}")
                 self._total_kv_tokens = -1
 

--- a/docs/kv_saturation.md
+++ b/docs/kv_saturation.md
@@ -17,7 +17,7 @@ The KV Saturation system eliminates this by ensuring a request is **only** admit
 ### 2. The Drip Mechanism
 In batch-heavy workloads, requests often finish in "cliffs"—where utilization drops significantly because the router waits for a full completion before admitting the next batch. This creates significant GPU idle time.
 
-The **Drip** functionality acts as a controlled "pressure valve" to smooth out these utilization cliffs. If a replica's physical KV cache usage falls below a specific threshold (decided by the user for now), the router will "drip" one extra request into that replica, even if the virtual budget is technically full. This ensures that as one batch finishes, there are still requests partially through their prefill/decode phase, raising the floor of average utilization.
+The **Drip** functionality acts as a controlled "pressure valve" to smooth out these utilization cliffs. This is used only when the virtual KV Cache for a replica is already exhausted.If a replica's physical KV cache usage falls below a specific threshold (decided by the user for now), the router will "drip" one extra request into that replica, even if the virtual budget is technically full. This ensures that as one batch finishes, there are still requests partially through their prefill/decode phase, raising the floor of average utilization.
 
 ## Configuration
 

--- a/docs/kv_saturation.md
+++ b/docs/kv_saturation.md
@@ -1,0 +1,48 @@
+# KV Saturation Flow Control
+
+The KV Saturation system is a flow control mechanism designed to maximize sampling throughput in memory-intensive sampling workloads by preventing KV cache preemptions.
+
+Currently, this feature is only available in the **Ray Serve** implementation.
+
+## Core Concepts
+
+### 1. Token Budgeting
+We have found that one of the causes of throughput collapse in vLLM is the "Recompute Tax" incurred when a GPU runs out of KV cache and must preempt (evict) a running request. Re-admitting that request requires a full recomputation of its prefix, which starves the GPU's compute bandwidth.
+
+The KV Saturation system eliminates this by ensuring a request is **only** admitted to a replica if that replica has enough theoretical capacity to serve the request from start to finish.
+
+*   **Learning Phase:** During the first encounter with a prompt, the router records the actual Input Sequence Length (ISL) and Output Sequence Length (OSL).
+*   **Virtual Reservation:** For all subsequent requests with the same fingerprint, the router calculates the full memory footprint of the request (ISL + OSL). It maintains a virtual counter of tokens occupied on each replica and will park new requests in an asynchronous queue if the addition of the new request would exceed the hardware's KV token budget.
+
+### 2. The Drip Mechanism
+In batch-heavy workloads, requests often finish in "cliffs"—where utilization drops significantly because the router waits for a full completion before admitting the next batch. This creates significant GPU idle time.
+
+The **Drip** functionality acts as a controlled "pressure valve" to smooth out these utilization cliffs. If a replica's physical KV cache usage falls below a specific threshold (decided by the user for now), the router will "drip" one extra request into that replica, even if the virtual budget is technically full. This ensures that as one batch finishes, there are still requests partially through their prefill/decode phase, raising the floor of average utilization.
+
+## Configuration
+
+The system is configured via the `flow_control` block in `scheduler_config.yaml`.
+
+### Example Configuration
+
+```yaml
+profiles:
+  default_profile:
+    flow_control:
+      use_token_budget: true      # Toggle to use KV saturation flow control
+      kv_budget_tokens: 727936    # Total tokens available on the hardware (this is a H200 at tp=2). In the future, this will be obtained programatically
+      default_osl: 1024           # OSL estimate for the very first contact (profiling)
+      drip_threshold_kv: 0.2      # Drip if physical KV usage < 20%
+      drip_interval_s: 2.0        # Limit drips to one every 2 seconds per replica
+```
+
+#### Strict Budgeting Mode (No Drip)
+To enforce a mathematically strict budget where preemptions are theoretically impossible, you should disable the drip mechanism by setting the threshold to zero and the interval to a maximum value:
+
+```yaml
+    flow_control:
+      use_token_budget: true
+      drip_threshold_kv: 0.0
+      drip_interval_s: 99999999.0
+```
+

--- a/docs/kv_saturation.md
+++ b/docs/kv_saturation.md
@@ -7,7 +7,7 @@ Currently, this feature is only available in the **Ray Serve** implementation.
 ## Core Concepts
 
 ### 1. Token Budgeting
-We have found that one of the causes of throughput collapse in vLLM is the "Recompute Tax" incurred when a GPU runs out of KV cache and must preempt (evict) a running request. Re-admitting that request requires a full recomputation of its prefix, which starves the GPU's compute bandwidth.
+We have found that one of the causes of throughput collapse in vLLM is the "Recompute Tax" incurred when a GPU runs out of KV cache and must preempt (evict) a running request. Re-admitting that request requires recomputation of the preempted tokens, which creates bubbles in the GPU decode batch.
 
 The KV Saturation system eliminates this by ensuring a request is **only** admitted to a replica if that replica has enough theoretical capacity to serve the request from start to finish.
 

--- a/docs/kv_saturation.md
+++ b/docs/kv_saturation.md
@@ -30,7 +30,6 @@ profiles:
   default_profile:
     flow_control:
       use_token_budget: true      # Toggle to use KV saturation flow control
-      kv_budget_tokens: 727936    # Total tokens available on the hardware (this is a H200 at tp=2). In the future, this will be obtained programatically
       default_osl: 1024           # OSL estimate for the very first contact (profiling)
       drip_threshold_kv: 0.2      # Drip if physical KV usage < 20%
       drip_interval_s: 2.0        # Limit drips to one every 2 seconds per replica

--- a/docs/kv_saturation.md
+++ b/docs/kv_saturation.md
@@ -9,7 +9,7 @@ Currently, this feature is only available in the **Ray Serve** implementation.
 ### 1. Token Budgeting
 We have found that one of the causes of throughput collapse in vLLM is the "Recompute Tax" incurred when a GPU runs out of KV cache and must preempt (evict) a running request. Re-admitting that request requires recomputation of the preempted tokens, which creates bubbles in the GPU decode batch.
 
-The KV Saturation system eliminates this by ensuring a request is **only** admitted to a replica if that replica has enough theoretical capacity to serve the request from start to finish.
+The KV Saturation system reduces this by ensuring a request is **only** admitted to a replica if that replica has enough theoretical capacity to serve the request from start to finish.
 
 *   **Learning Phase:** During the first encounter with a prompt, the router records the actual Input Sequence Length (ISL) and Output Sequence Length (OSL).
 *   **Virtual Reservation:** For all subsequent requests with the same fingerprint, the router calculates the full memory footprint of the request (ISL + OSL). It maintains a virtual counter of tokens occupied on each replica and will park new requests in an asynchronous queue if the addition of the new request would exceed the hardware's KV token budget.

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -86,6 +86,7 @@ class IGWRouter(RequestRouter):
         self._last_drip_at = 0.0
         self._loop: asyncio.AbstractEventLoop | None = None
         self._budgeted_requests: set[str] = set()
+        self._replica_kv_cache_size: dict[ReplicaID, int] = {}
 
     async def _get_routing_stats(
         self, replicas: list[RunningReplica], pending_request: PendingRequest
@@ -99,7 +100,9 @@ class IGWRouter(RequestRouter):
         return [res if not isinstance(res, Exception) else {} for res in results]
 
     def _get_request_id(self, pending_request: PendingRequest) -> tuple[str, int]:
-        """Deterministic request ID from prompt and approx character length."""
+        """Request ID from prompt and approx character length.
+        We don't require character length to be accurate, it is used as a fail-safe and for edge cases.
+        """
         try:
             if not pending_request or not pending_request.args:
                 return "", 0
@@ -142,15 +145,19 @@ class IGWRouter(RequestRouter):
     def _get_available_replicas(
         self,
         candidate_replicas: list[RunningReplica],
-        total_required: int,
-        kv_budget_tokens: int,
+        tokens_required: int,
     ) -> list[RunningReplica]:
         """Return subset of replicas that can fit the required tokens."""
-        return [
-            r
-            for r in candidate_replicas
-            if self._replica_token_usage.get(r.replica_id, 0) + total_required <= kv_budget_tokens
-        ]
+        res = []
+        for r in candidate_replicas:
+            budget = self._replica_kv_cache_size.get(r.replica_id)
+            if budget is not None and budget > 0:
+                if (
+                    self._replica_token_usage.get(r.replica_id, 0) + tokens_required
+                    <= budget
+                ):
+                    res.append(r)
+        return res
 
     async def choose_replicas(  # noqa: PLR0912
         self,
@@ -187,6 +194,15 @@ class IGWRouter(RequestRouter):
                     print(f"Failed to fetch metrics via RPC for {replica_id}: {routing_stats}")
                     routing_stats = {}  # noqa: PLW2901
 
+                # Discover and cache KV Cache size if not already known
+                if replica_id not in self._replica_kv_cache_size:
+                    kv_cache_size = routing_stats.get("kv_cache_size", -1)
+                    if kv_cache_size > 0:
+                        self._replica_kv_cache_size[replica_id] = kv_cache_size
+                        print(
+                            f"[BUDGET] Discovered KV Cache size for replica {replica_id}: {kv_cache_size} tokens"
+                        )
+
                 candidates.append(
                     Endpoint(
                         name=str(replica.replica_id),
@@ -200,28 +216,31 @@ class IGWRouter(RequestRouter):
             fc = self.scheduler.get_flow_control_config()
             use_token_budget = fc.get("use_token_budget", _DEFAULT_USE_TOKEN_BUDGET)
 
-            total_required = 0
+            tokens_required = 0
             is_budgeted = False
 
-            if use_token_budget and request_id and request_id not in self._budgeted_requests:
-                kv_budget_tokens = fc.get("kv_budget_tokens", 727_936)
-                default_osl = fc.get("default_osl", 2000)
+            if (
+                use_token_budget
+                and request_id
+                and request_id not in self._budgeted_requests
+            ):
+                default_osl = fc.get("default_osl", 1024)
                 drip_threshold_kv = fc.get("drip_threshold_kv", 0.1)
                 drip_interval_s = fc.get("drip_interval_s", 2.0)
                 stats = self._rollout_request_stats.get(rollout_request_id)
 
                 if stats:
-                    total_required = stats["isl"] + stats["osl"]
+                    tokens_required = stats["isl"] + stats["osl"]
                     is_budgeted = True
                 else:
                     # Fallback for first contact with prompt
-                    total_required = (char_len // 4) + default_osl
+                    tokens_required = (char_len // 4) + default_osl
                     is_budgeted = True
 
                 if is_budgeted:
                     while True:
                         available_replicas = self._get_available_replicas(
-                            candidate_replicas, total_required, kv_budget_tokens
+                            candidate_replicas, tokens_required
                         )
 
                         if available_replicas:
@@ -299,11 +318,11 @@ class IGWRouter(RequestRouter):
             # Commit the reservation for the selected replica
             if is_budgeted:
                 self._replica_token_usage[target_replica_id] = (
-                    self._replica_token_usage.get(target_replica_id, 0) + total_required
+                    self._replica_token_usage.get(target_replica_id, 0) + tokens_required
                 )
                 self._request_at_replica[request_id] = (
                     target_replica_id,
-                    total_required,
+                    tokens_required,
                 )
                 self._budgeted_requests.add(request_id)
                 print(

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -18,7 +18,7 @@ import asyncio
 import random
 import struct
 import time
-from typing import Callable
+from typing import Any, Callable
 import uuid
 
 from ray import serve
@@ -99,17 +99,37 @@ class IGWRouter(RequestRouter):
         results = await asyncio.gather(*futures, return_exceptions=True)
         return [res if not isinstance(res, Exception) else {} for res in results]
 
-    def _get_request_id(self, pending_request: PendingRequest) -> tuple[str, int]:
-        """Request ID from prompt and approx character length.
+    def _parse_to_llm_request(self, pending_request: PendingRequest) -> LLMRequest:
+        """Converts Ray request to LLMRequest."""
+        if pending_request:
+            req_id = pending_request.metadata.request_id
+        else:
+            req_id = str(uuid.uuid4())
+
+        if not pending_request or not pending_request.args:
+            return LLMRequest(request_id=req_id, body="", target_model="qwen-32b")
+        request_args = pending_request.args[0]
+
+        if hasattr(request_args, "messages"):
+            body = request_args.messages
+        elif hasattr(request_args, "prompt"):
+            body = request_args.prompt
+        else:
+            body = request_args
+
+        # make configurable in LLMConfig
+        target_model = getattr(request_args, "model", "qwen-32b")
+
+        return LLMRequest(request_id=req_id, body=body, target_model=target_model)
+
+    def _get_rollout_request_id(self, body: Any) -> tuple[str, int]:
+        """Generates a rollout request ID and approximate character length from the request body.
         We don't require character length to be accurate, it is used as a fail-safe and for edge cases.
         """
+        if not body:
+            return "", 0
+
         try:
-            if not pending_request or not pending_request.args:
-                return "", 0
-
-            request_args = pending_request.args[0]
-            body = getattr(request_args, "messages", getattr(request_args, "prompt", ""))
-
             # Case 1: Pre-tokenized prompt ids (List[int])
             if isinstance(body, list) and len(body) > 0 and isinstance(body[0], int):
                 prompt_bytes = struct.pack(f"{len(body)}i", *body)
@@ -170,8 +190,9 @@ class IGWRouter(RequestRouter):
         if not candidate_replicas:
             return []
 
-        request_id = pending_request.metadata.request_id if pending_request else None
-        rollout_request_id, char_len = self._get_request_id(pending_request)
+        llm_req = self._parse_to_llm_request(pending_request)
+        rollout_request_id, char_len = self._get_rollout_request_id(llm_req.body)
+        request_id = llm_req.request_id
 
         # for health check empty requests
         if not pending_request or not pending_request.args or char_len == 0:
@@ -190,10 +211,6 @@ class IGWRouter(RequestRouter):
                     if cached_val is not None:
                         queue_len = cached_val
 
-                if isinstance(routing_stats, Exception):
-                    print(f"Failed to fetch metrics via RPC for {replica_id}: {routing_stats}")
-                    routing_stats = {}  # noqa: PLW2901
-
                 # Discover and cache KV Cache size if not already known
                 if replica_id not in self._replica_kv_cache_size:
                     kv_cache_size = routing_stats.get("kv_cache_size", -1)
@@ -202,6 +219,10 @@ class IGWRouter(RequestRouter):
                         print(
                             f"[BUDGET] Discovered KV Cache size for replica {replica_id}: {kv_cache_size} tokens"
                         )
+
+                if isinstance(routing_stats, Exception):
+                    print(f"Failed to fetch metrics via RPC for {replica_id}: {routing_stats}")
+                    routing_stats = {}  # noqa: PLW2901
 
                 candidates.append(
                     Endpoint(
@@ -289,17 +310,7 @@ class IGWRouter(RequestRouter):
 
             self.scheduler._maybe_reload_config()
 
-            request_args = pending_request.args[0]
-            if hasattr(request_args, "messages"):
-                body = request_args.messages
-            elif hasattr(request_args, "prompt"):
-                body = request_args.prompt
-            else:
-                body = request_args
-
-            igw_req = LLMRequest(request_id="1", body=body, target_model="qwen-32b")
-
-            selected_endpoints = self.scheduler.run(igw_req, candidates)
+            selected_endpoints = self.scheduler.run(llm_req, candidates)
 
             index = -1
             for i, replica in enumerate(candidate_replicas):
@@ -341,8 +352,9 @@ class IGWRouter(RequestRouter):
         replica_id: ReplicaID,
         result: ReplicaResult,
     ):
-        request_id = pending_request.metadata.request_id
-        rollout_request_id, char_len = self._get_request_id(pending_request)
+        llm_req = self._parse_to_llm_request(pending_request)
+        request_id = llm_req.request_id
+        rollout_request_id, char_len = self._get_rollout_request_id(llm_req.body)
         routed_at = time.time()
         is_streaming = pending_request.metadata.is_streaming
 

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -18,8 +18,8 @@ import asyncio
 import random
 import struct
 import time
-from typing import Any, Callable
 import uuid
+from typing import Any, Callable
 
 from ray import serve
 from ray.actor import ActorHandle
@@ -79,9 +79,11 @@ class IGWRouter(RequestRouter):
         )
         self.scheduler = Scheduler()
         self.deployment_name = deployment_id.name
-        self._rollout_request_stats: dict[str, dict[str, int]] = {}  # rollout_request_id -> {isl, max_osl}
+        # rollout_request_id -> {isl, max_osl}
+        self._rollout_request_stats: dict[str, dict[str, int]] = {}
         self._replica_token_usage: dict[ReplicaID, int] = {}  # replica_id -> token_usage_at_replica
-        self._request_at_replica: dict[str, tuple[ReplicaID, int]] = {}  # request_id -> (replica_id, tokens)
+        # request_id -> (replica_id, tokens)
+        self._request_at_replica: dict[str, tuple[ReplicaID, int]] = {}
         self._admission_queue: list[asyncio.Future] = []  # FIFO queue for blocked requests
 
         self._last_drip_at = 0.0
@@ -102,10 +104,7 @@ class IGWRouter(RequestRouter):
 
     def _parse_to_llm_request(self, pending_request: PendingRequest) -> LLMRequest:
         """Converts Ray request to LLMRequest."""
-        if pending_request:
-            req_id = pending_request.metadata.request_id
-        else:
-            req_id = str(uuid.uuid4())
+        req_id = pending_request.metadata.request_id if pending_request else str(uuid.uuid4())
 
         if not pending_request or not pending_request.args:
             print("No pending request or args, defaulting to random choice")
@@ -125,9 +124,11 @@ class IGWRouter(RequestRouter):
 
         return LLMRequest(request_id=req_id, body=body, target_model=target_model)
 
-    def _get_rollout_request_id(self, body: Any) -> tuple[str, int]:
+    def _get_rollout_request_id(self, body: Any) -> tuple[str, int]:  # noqa: ANN401
         """Generates a rollout request ID and approximate character length from the request body.
-        We don't require character length to be accurate, it is used as a fail-safe and for edge cases.
+
+        We don't require character length to be accurate, it is used as a
+        fail-safe and for edge cases.
         """
         if not body:
             return "", 0
@@ -154,7 +155,7 @@ class IGWRouter(RequestRouter):
                 char_len = len(extracted_text)
                 return uuid.uuid5(NAMESPACE_FOR_UUID, extracted_text).hex, char_len
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"[ROUTER ERROR] Failed to parse request ID securely: {e}")
 
         return "", 0
@@ -174,12 +175,11 @@ class IGWRouter(RequestRouter):
         res = []
         for r in candidate_replicas:
             budget = self._replica_kv_cache_size.get(r.replica_id)
-            if budget is not None and budget > 0:
-                if (
-                    self._replica_token_usage.get(r.replica_id, 0) + tokens_required
-                    <= budget
-                ):
-                    res.append(r)
+            if budget is not None and budget > 0 and (
+                self._replica_token_usage.get(r.replica_id, 0) + tokens_required
+                <= budget
+            ):
+                res.append(r)
         return res
 
     def _token_budget_needed(self, request_id: str | None, fc: dict) -> bool:
@@ -239,7 +239,7 @@ class IGWRouter(RequestRouter):
 
             await self._wait_for_space()
 
-    async def choose_replicas(  # noqa: PLR0912
+    async def choose_replicas(  # noqa: PLR0912, PLR0914, C901, PLR0915
         self,
         candidate_replicas: list[RunningReplica],
         pending_request: PendingRequest | None = None,
@@ -256,7 +256,7 @@ class IGWRouter(RequestRouter):
 
         # for health check empty requests
         if not pending_request or not pending_request.args or char_len == 0:
-            index = random.randint(0, len(candidate_replicas) - 1)
+            index = random.randint(0, len(candidate_replicas) - 1)  # noqa: S311
             return [[candidate_replicas[index]]]
 
         try:
@@ -277,7 +277,8 @@ class IGWRouter(RequestRouter):
                     if kv_cache_size > 0:
                         self._replica_kv_cache_size[replica_id] = kv_cache_size
                         print(
-                            f"[BUDGET] Discovered KV Cache size for replica {replica_id}: {kv_cache_size} tokens"
+                            f"[BUDGET] Discovered KV Cache size for replica {replica_id}: "
+                            f"{kv_cache_size} tokens"
                         )
 
                 if isinstance(routing_stats, Exception):
@@ -324,7 +325,7 @@ class IGWRouter(RequestRouter):
                     index = i
                     break
             if index == -1:
-                index = random.randint(0, len(candidate_replicas) - 1)
+                index = random.randint(0, len(candidate_replicas) - 1)  # noqa: S311
 
             target_replica = candidate_replicas[index]
             target_replica_id = target_replica.replica_id
@@ -340,13 +341,15 @@ class IGWRouter(RequestRouter):
                 )
                 self._budgeted_requests.add(request_id)
                 print(
-                    f"[BUDGET] Admission committed for req={request_id} to replica={target_replica_id} (Usage: {self._replica_token_usage[target_replica_id]})"
+                    f"[BUDGET] Admission committed for req={request_id} "
+                    f"to replica={target_replica_id} "
+                    f"(Usage: {self._replica_token_usage[target_replica_id]})"
                 )
 
-            return [[target_replica]]
-        except Exception as e:
+            return [[target_replica]]  # noqa: TRY300
+        except Exception as e:  # noqa: BLE001
             print(f"Error of: {e!r} during scheduling: {e}, defaulting to random choice")
-            index = random.randint(0, len(candidate_replicas) - 1)
+            index = random.randint(0, len(candidate_replicas) - 1)  # noqa: S311
             return [[candidate_replicas[index]]]
 
     def on_request_routed(
@@ -354,7 +357,7 @@ class IGWRouter(RequestRouter):
         pending_request: PendingRequest,
         replica_id: ReplicaID,
         result: ReplicaResult,
-    ):
+    ) -> None:
         llm_req = self._parse_to_llm_request(pending_request)
         request_id = llm_req.request_id
         rollout_request_id, char_len = self._get_rollout_request_id(llm_req.body)
@@ -371,7 +374,8 @@ class IGWRouter(RequestRouter):
                 self._budgeted_requests.discard(request_id)
                 print(
                     f"[BUDGET] Released req={request_id} from replica={replica_id_to_reclaim}. "
-                    f"Elapsed={elapsed:.3f}s. Usage={self._replica_token_usage[replica_id_to_reclaim]}"
+                    f"Elapsed={elapsed:.3f}s. "
+                    f"Usage={self._replica_token_usage[replica_id_to_reclaim]}"
                 )
 
                 if self._admission_queue:
@@ -413,26 +417,25 @@ class IGWRouter(RequestRouter):
 # Hooking into Ray Serve's Request Router
 
 llm_config = LLMConfig(
-    model_loading_config=dict(
-        model_id="qwen-32b",
-        model_source="Qwen/Qwen2.5-32B-Instruct",
-    ),
-    engine_kwargs=dict(
-        enable_prefix_caching=True,
-        tensor_parallel_size=2,
-    ),
-    deployment_config=dict(
-        # max_ongoing_requests=10,
-        autoscaling_config=dict(
-            min_replicas=1,
-            max_replicas=1,
-        ),
-        request_router_config=dict(
+    model_loading_config={
+        "model_id": "qwen-32b",
+        "model_source": "Qwen/Qwen2.5-32B-Instruct",
+    },
+    engine_kwargs={
+        "enable_prefix_caching": True,
+        "tensor_parallel_size": 2,
+    },
+    deployment_config={
+        "autoscaling_config": {
+            "min_replicas": 1,
+            "max_replicas": 1,
+        },
+        "request_router_config": {
             # Note our custom IGWRouter here
-            request_router_class=IGWRouter,
-        ),
-        ray_actor_options=dict(num_cpus=1),
-    ),
+            "request_router_class": IGWRouter,
+        },
+        "ray_actor_options": {"num_cpus": 1},
+    },
     runtime_env={
         "env_vars": {
             "NCCL_NET_PLUGIN": "/usr/local/gib/lib64/libnccl-net_internal.so",

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from __future__ import annotations
 
 import asyncio
 import random
+import struct
 import time
 from typing import Callable
+import uuid
 
 from ray import serve
 from ray.actor import ActorHandle
@@ -30,12 +31,12 @@ from ray.llm._internal.serve.core.server.builder import build_llm_deployment  # 
 from ray.serve._private.common import (
     DeploymentHandleSource,
     DeploymentID,
-    ReplicaID,
     RunningReplicaInfo,
 )
 from ray.serve.llm import LLMConfig
 from ray.serve.request_router import (
     PendingRequest,
+    ReplicaID,
     ReplicaResult,
     RequestRouter,
     RunningReplica,
@@ -47,6 +48,9 @@ from scheduling.framework import (
     Endpoint,
     LLMRequest,
 )
+
+NAMESPACE_FOR_UUID = uuid.uuid5(uuid.NAMESPACE_DNS, "llmd.inference.scheduler")
+_DEFAULT_USE_TOKEN_BUDGET = False
 
 
 class IGWRouter(RequestRouter):
@@ -73,60 +77,114 @@ class IGWRouter(RequestRouter):
             create_replica_wrapper_func=create_replica_wrapper_func,
             **kwargs,
         )
-        # Initialize the RayRequestScheduler
         self.scheduler = Scheduler()
+        self._rollout_request_stats: dict[str, dict[str, int]] = {}  # rollout_request_id -> {isl, max_osl}
+        self._replica_token_usage: dict[ReplicaID, int] = {}  # replica_id -> token_usage_at_replica
+        self._request_at_replica: dict[str, tuple[ReplicaID, int]] = {}  # request_id -> (replica_id, tokens)
+        self._admission_queue: list[asyncio.Future] = []  # FIFO queue for blocked requests
+
+        self._last_drip_at = 0.0
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._budgeted_requests: set[str] = set()
+
+    async def _get_routing_stats(
+        self, replicas: list[RunningReplica], pending_request: PendingRequest
+    ) -> list[dict]:
+        """Fetch routing stats (KV usage, etc.) from a list of replicas."""
+        futures = [
+            r._get_replica_wrapper(pending_request)._actor_handle.record_routing_stats.remote()
+            for r in replicas
+        ]
+        results = await asyncio.gather(*futures, return_exceptions=True)
+        return [res if not isinstance(res, Exception) else {} for res in results]
+
+    def _get_request_id(self, pending_request: PendingRequest) -> tuple[str, int]:
+        """Deterministic request ID from prompt and approx character length."""
+        try:
+            if not pending_request or not pending_request.args:
+                return "", 0
+
+            request_args = pending_request.args[0]
+            body = getattr(request_args, "messages", getattr(request_args, "prompt", ""))
+
+            # Case 1: Pre-tokenized prompt ids (List[int])
+            if isinstance(body, list) and len(body) > 0 and isinstance(body[0], int):
+                prompt_bytes = struct.pack(f"{len(body)}i", *body)
+                return uuid.uuid5(NAMESPACE_FOR_UUID, prompt_bytes.hex()).hex, len(body) * 4
+
+            # Case 2: Raw string or bytes prompt
+            if isinstance(body, (str, bytes)):
+                prompt_str = body if isinstance(body, str) else body.hex()
+                return uuid.uuid5(NAMESPACE_FOR_UUID, prompt_str).hex, len(body)
+
+            # Case 3: List of messages (Dicts/Pydantic models)
+            if isinstance(body, list):
+                extracted_text = ""
+                for m in body:
+                    if isinstance(m, dict):
+                        extracted_text += str(m.get("content", ""))
+                    else:
+                        extracted_text += str(getattr(m, "content", ""))
+                char_len = len(extracted_text)
+                return uuid.uuid5(NAMESPACE_FOR_UUID, extracted_text).hex, char_len
+
+        except Exception as e:
+            print(f"[ROUTER ERROR] Failed to parse request ID securely: {e}")
+
+        return "", 0
+
+    async def _wait_for_space(self) -> None:
+        """Wait until at least one replica has space freed up."""
+        fut = self._loop.create_future()
+        self._admission_queue.append(fut)
+        await fut
+
+    def _get_available_replicas(
+        self,
+        candidate_replicas: list[RunningReplica],
+        total_required: int,
+        kv_budget_tokens: int,
+    ) -> list[RunningReplica]:
+        """Return subset of replicas that can fit the required tokens."""
+        return [
+            r
+            for r in candidate_replicas
+            if self._replica_token_usage.get(r.replica_id, 0) + total_required <= kv_budget_tokens
+        ]
 
     async def choose_replicas(  # noqa: PLR0912
         self,
         candidate_replicas: list[RunningReplica],
         pending_request: PendingRequest | None = None,
     ) -> list[list[RunningReplica]]:
-        self.scheduler._maybe_reload_config()
+        if self._loop is None:
+            self._loop = asyncio.get_event_loop()
 
-        if not pending_request or not pending_request.args:
-            print("No pending request or args, defaulting to random choice")
-            index = random.randint(0, len(candidate_replicas) - 1)  # noqa: S311
-            final = time.time()
+        if not candidate_replicas:
+            return []
+
+        request_id = pending_request.metadata.request_id if pending_request else None
+        rollout_request_id, char_len = self._get_request_id(pending_request)
+
+        # for health check empty requests
+        if not pending_request or not pending_request.args or char_len == 0:
+            index = random.randint(0, len(candidate_replicas) - 1)
             return [[candidate_replicas[index]]]
 
         try:
-            print("Using scheduling library to route request")
-            print("Pending request:", pending_request)
-            initial = time.time()
-
-            request_args = pending_request.args[0]
-            if hasattr(request_args, "messages"):
-                body = request_args.messages
-            elif hasattr(request_args, "prompt"):
-                body = request_args.prompt
-            else:
-                body = request_args
-
-            igw_req = LLMRequest(request_id="1", body=body, target_model="qwen-32b")
-            print("IGW Request body:", igw_req.body)
-
-            metrics_futures = [
-                replica._get_replica_wrapper(
-                    pending_request
-                )._actor_handle.record_routing_stats.remote()
-                for replica in candidate_replicas
-            ]
-
-            metrics_results = await asyncio.gather(
-                *metrics_futures, return_exceptions=True
-            )
+            metrics_results = await self._get_routing_stats(candidate_replicas, pending_request)
 
             candidates = []
             for replica, routing_stats in zip(candidate_replicas, metrics_results):
                 queue_len = 0
-                rid = replica.replica_id
+                replica_id = replica.replica_id
                 if self.replica_queue_len_cache:
-                    cached_val = self.replica_queue_len_cache.get(rid)
+                    cached_val = self.replica_queue_len_cache.get(replica_id)
                     if cached_val is not None:
                         queue_len = cached_val
 
                 if isinstance(routing_stats, Exception):
-                    print(f"Failed to fetch metrics via RPC for {rid}: {routing_stats}")
+                    print(f"Failed to fetch metrics via RPC for {replica_id}: {routing_stats}")
                     routing_stats = {}  # noqa: PLW2901
 
                 candidates.append(
@@ -139,12 +197,91 @@ class IGWRouter(RequestRouter):
                     )
                 )
 
+            fc = self.scheduler.get_flow_control_config()
+            use_token_budget = fc.get("use_token_budget", _DEFAULT_USE_TOKEN_BUDGET)
+
+            total_required = 0
+            is_budgeted = False
+
+            if use_token_budget and request_id and request_id not in self._budgeted_requests:
+                kv_budget_tokens = fc.get("kv_budget_tokens", 727_936)
+                default_osl = fc.get("default_osl", 2000)
+                drip_threshold_kv = fc.get("drip_threshold_kv", 0.1)
+                drip_interval_s = fc.get("drip_interval_s", 2.0)
+                stats = self._rollout_request_stats.get(rollout_request_id)
+
+                if stats:
+                    total_required = stats["isl"] + stats["osl"]
+                    is_budgeted = True
+                else:
+                    # Fallback for first contact with prompt
+                    total_required = (char_len // 4) + default_osl
+                    is_budgeted = True
+
+                if is_budgeted:
+                    while True:
+                        available_replicas = self._get_available_replicas(
+                            candidate_replicas, total_required, kv_budget_tokens
+                        )
+
+                        if available_replicas:
+                            candidate_replicas = available_replicas
+                            candidates = [
+                                c
+                                for c in candidates
+                                if c.name in [str(r.replica_id) for r in candidate_replicas]
+                            ]
+                            break
+                        else:
+                            new_metrics = await self._get_routing_stats(
+                                candidate_replicas, pending_request
+                            )
+                            for i, res in enumerate(new_metrics):
+                                candidates[i].attributes["routing_stats"] = res
+
+                            now = time.time()
+                            best_drip_replica = None
+                            for i, r in enumerate(candidate_replicas):
+                                stats = candidates[i].attributes.get("routing_stats", {})
+                                physical_kv = stats.get("kv", 1.0)
+
+                                if (
+                                    physical_kv < drip_threshold_kv
+                                    and (now - self._last_drip_at) > drip_interval_s
+                                ):
+                                    best_drip_replica = r
+                                    break
+
+                            if best_drip_replica:
+                                self._last_drip_at = now
+                                print(
+                                    f"[BUDGET] Drip Admission: req={request_id} to {best_drip_replica.replica_id} (Physical KV: {physical_kv:.2f})"
+                                )
+                                candidate_replicas = [best_drip_replica]
+                                candidates = [
+                                    c
+                                    for c in candidates
+                                    if c.name == str(best_drip_replica.replica_id)
+                                ]
+                                is_budgeted = True
+                                break
+
+                        await self._wait_for_space()
+
+            self.scheduler._maybe_reload_config()
+
+            request_args = pending_request.args[0]
+            if hasattr(request_args, "messages"):
+                body = request_args.messages
+            elif hasattr(request_args, "prompt"):
+                body = request_args.prompt
+            else:
+                body = request_args
+
+            igw_req = LLMRequest(request_id="1", body=body, target_model="qwen-32b")
+
             selected_endpoints = self.scheduler.run(igw_req, candidates)
 
-            if len(selected_endpoints) > 0:
-                print(f"Routed to endpoint: {selected_endpoints[0].endpoint.name}\n")
-            else:
-                print("No endpoint selected by scheduler\n")
             index = -1
             for i, replica in enumerate(candidate_replicas):
                 if (
@@ -154,15 +291,29 @@ class IGWRouter(RequestRouter):
                     index = i
                     break
             if index == -1:
-                index = random.randint(0, len(candidate_replicas) - 1)  # noqa: S311
-            final = time.time()
-            print(f"Scheduling took {final - initial} seconds")
-            return [[candidate_replicas[index]]]
-        except Exception as e:  # noqa: BLE001
-            print(
-                f"Error of: {e!r} during scheduling: {e}, defaulting to random choice"
-            )
-            index = random.randint(0, len(candidate_replicas) - 1)  # noqa: S311
+                index = random.randint(0, len(candidate_replicas) - 1)
+
+            target_replica = candidate_replicas[index]
+            target_replica_id = target_replica.replica_id
+
+            # Commit the reservation for the selected replica
+            if is_budgeted:
+                self._replica_token_usage[target_replica_id] = (
+                    self._replica_token_usage.get(target_replica_id, 0) + total_required
+                )
+                self._request_at_replica[request_id] = (
+                    target_replica_id,
+                    total_required,
+                )
+                self._budgeted_requests.add(request_id)
+                print(
+                    f"[BUDGET] Admission committed for req={request_id} to replica={target_replica_id} (Usage: {self._replica_token_usage[target_replica_id]})"
+                )
+
+            return [[target_replica]]
+        except Exception as e:
+            print(f"Error of: {e!r} during scheduling: {e}, defaulting to random choice")
+            index = random.randint(0, len(candidate_replicas) - 1)
             return [[candidate_replicas[index]]]
 
     def on_request_routed(
@@ -170,10 +321,99 @@ class IGWRouter(RequestRouter):
         pending_request: PendingRequest,
         replica_id: ReplicaID,
         result: ReplicaResult,
-    ) -> None:
-        # Not currently used, but could be hooked into for the PreRequest hook.
-        # But intentionally keeping the py-scheduler framework isolated from Ray Serve
-        print("on_request_routed callback is called")
+    ):
+        request_id = pending_request.metadata.request_id
+        rollout_request_id, char_len = self._get_request_id(pending_request)
+        routed_at = time.time()
+        is_streaming = pending_request.metadata.is_streaming
+
+        def _on_done(_):
+            elapsed = time.time() - routed_at
+            if request_id in self._request_at_replica:
+                replica_id_to_reclaim, tokens = self._request_at_replica.pop(request_id)
+                self._replica_token_usage[replica_id_to_reclaim] = max(
+                    0, self._replica_token_usage.get(replica_id_to_reclaim, 0) - tokens
+                )
+                self._budgeted_requests.discard(request_id)
+                print(
+                    f"[BUDGET] Released req={request_id} from replica={replica_id_to_reclaim}. "
+                    f"Elapsed={elapsed:.3f}s. Usage={self._replica_token_usage[replica_id_to_reclaim]}"
+                )
+
+                if self._admission_queue:
+                    waiter = self._admission_queue.pop(0)
+                    if not waiter.done():
+                        waiter.set_result(True)
+
+        result.add_done_callback(_on_done)
+
+        if char_len > 0:
+            if not is_streaming:
+                original_get_async = result.get_async
+
+                async def patched_get_async():
+                    response = await original_get_async()
+                    if response and hasattr(response, "usage") and response.usage:
+                        self._rollout_request_stats[rollout_request_id] = {
+                            "isl": response.usage.prompt_tokens,
+                            "osl": response.usage.completion_tokens,
+                        }
+                    return response
+
+                result.get_async = patched_get_async
+            else:
+                original_anext = result.__anext__
+
+                async def patched_anext():
+                    chunk = await original_anext()
+                    if chunk and hasattr(chunk, "usage") and chunk.usage:
+                        self._rollout_request_stats[rollout_request_id] = {
+                            "isl": chunk.usage.prompt_tokens,
+                            "osl": chunk.usage.completion_tokens,
+                        }
+                    return chunk
+
+                result.__anext__ = patched_anext
+
+
+# Hooking into Ray Serve's Request Router
+
+llm_config = LLMConfig(
+    model_loading_config=dict(
+        model_id="qwen-32b",
+        model_source="Qwen/Qwen2.5-32B-Instruct",
+    ),
+    engine_kwargs=dict(
+        enable_prefix_caching=True,
+        tensor_parallel_size=2,
+    ),
+    deployment_config=dict(
+        # max_ongoing_requests=10,
+        autoscaling_config=dict(
+            min_replicas=1,
+            max_replicas=1,
+        ),
+        request_router_config=dict(
+            # Note our custom IGWRouter here
+            request_router_class=IGWRouter,
+        ),
+        ray_actor_options=dict(num_cpus=1),
+    ),
+    runtime_env={
+        "env_vars": {
+            "NCCL_NET_PLUGIN": "/usr/local/gib/lib64/libnccl-net_internal.so",
+            "NCCL_CROSS_NIC": "0",
+            "NCCL_NET_GDR_LEVEL": "PIX",
+            "NCCL_P2P_NET_CHUNKSIZE": "131072",
+            "NCCL_NVLS_CHUNKSIZE": "524288",
+            "NCCL_IB_ADAPTIVE_ROUTING": "1",
+            "NCCL_IB_QPS_PER_CONNECTION": "4",
+            "NCCL_IB_TC": "52",
+            "NCCL_IB_FIFO_TC": "84",
+            "NCCL_TUNER_CONFIG_PATH": "/usr/local/gib/configs/tuner_config_a3u.txtpb",
+        }
+    },
+)
 
 
 def build_custom_openai_app(builder_config: dict[str, object]) -> object:
@@ -182,40 +422,18 @@ def build_custom_openai_app(builder_config: dict[str, object]) -> object:
     llm_configs = builder_config.llm_configs
 
     llm_deployments = [
-        build_llm_deployment(c, deployment_cls=MetricsAwareLLMServer)
-        for c in llm_configs
+        build_llm_deployment(c, deployment_cls=MetricsAwareLLMServer) for c in llm_configs
     ]
 
     ingress_cls_config = builder_config.ingress_cls_config
     ingress_options = ingress_cls_config.ingress_cls.get_deployment_options(llm_configs)
     ingress_cls = make_fastapi_ingress(ingress_cls_config.ingress_cls)
-    return serve.deployment(ingress_cls, **ingress_options).bind(
-        llm_deployments=llm_deployments, **ingress_cls_config.ingress_extra_kwargs
-    )
 
+    return serve.deployment(
+        ingress_cls,
+        **ingress_options,
+    ).bind(llm_deployments=llm_deployments, **ingress_cls_config.ingress_extra_kwargs)
 
-# Hooking into Ray Serve's Request Router
-
-llm_config = LLMConfig(
-    model_loading_config={
-        "model_id": "qwen-32b",
-        "model_source": "Qwen/Qwen2.5-32B-Instruct",
-    },
-    engine_kwargs={
-        "enable_prefix_caching": True,
-    },
-    deployment_config={
-        "autoscaling_config": {
-            "min_replicas": 6,
-            "max_replicas": 6,
-        },
-        "request_router_config": {
-            # Note our custom IGWRouter here
-            "request_router_class": IGWRouter,
-        },
-        "ray_actor_options": {"num_cpus": 1},
-    },
-)
 
 app = build_custom_openai_app(
     {

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -78,6 +78,7 @@ class IGWRouter(RequestRouter):
             **kwargs,
         )
         self.scheduler = Scheduler()
+        self.deployment_name = deployment_id.name
         self._rollout_request_stats: dict[str, dict[str, int]] = {}  # rollout_request_id -> {isl, max_osl}
         self._replica_token_usage: dict[ReplicaID, int] = {}  # replica_id -> token_usage_at_replica
         self._request_at_replica: dict[str, tuple[ReplicaID, int]] = {}  # request_id -> (replica_id, tokens)
@@ -107,7 +108,10 @@ class IGWRouter(RequestRouter):
             req_id = str(uuid.uuid4())
 
         if not pending_request or not pending_request.args:
-            return LLMRequest(request_id=req_id, body="", target_model="qwen-32b")
+            print("No pending request or args, defaulting to random choice")
+            return LLMRequest(
+                request_id=req_id, body="", target_model=self.deployment_name
+            )
         request_args = pending_request.args[0]
 
         if hasattr(request_args, "messages"):
@@ -117,8 +121,7 @@ class IGWRouter(RequestRouter):
         else:
             body = request_args
 
-        # make configurable in LLMConfig
-        target_model = getattr(request_args, "model", "qwen-32b")
+        target_model = getattr(request_args, "model", self.deployment_name)
 
         return LLMRequest(request_id=req_id, body=body, target_model=target_model)
 

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -265,24 +265,23 @@ class IGWRouter(RequestRouter):
             candidates = []
             for replica, routing_stats in zip(candidate_replicas, metrics_results):
                 queue_len = 0
-                replica_id = replica.replica_id
                 if self.replica_queue_len_cache:
-                    cached_val = self.replica_queue_len_cache.get(replica_id)
+                    cached_val = self.replica_queue_len_cache.get(replica.replica_id)
                     if cached_val is not None:
                         queue_len = cached_val
 
                 # Discover and cache KV Cache size if not already known
-                if replica_id not in self._replica_kv_cache_size:
+                if replica.replica_id not in self._replica_kv_cache_size:
                     kv_cache_size = routing_stats.get("kv_cache_size", -1)
                     if kv_cache_size > 0:
-                        self._replica_kv_cache_size[replica_id] = kv_cache_size
+                        self._replica_kv_cache_size[replica.replica_id] = kv_cache_size
                         print(
-                            f"[BUDGET] Discovered KV Cache size for replica {replica_id}: "
+                            f"[BUDGET] Discovered KV Cache size for replica {replica.replica_id}: "
                             f"{kv_cache_size} tokens"
                         )
 
                 if isinstance(routing_stats, Exception):
-                    print(f"Failed to fetch metrics via RPC for {replica_id}: {routing_stats}")
+                    print(f"Failed to fetch metrics via RPC for {replica.replica_id}: {routing_stats}")
                     routing_stats = {}  # noqa: PLW2901
 
                 candidates.append(
@@ -328,22 +327,21 @@ class IGWRouter(RequestRouter):
                 index = random.randint(0, len(candidate_replicas) - 1)  # noqa: S311
 
             target_replica = candidate_replicas[index]
-            target_replica_id = target_replica.replica_id
 
             # Commit the reservation for the selected replica
             if is_budgeted:
-                self._replica_token_usage[target_replica_id] = (
-                    self._replica_token_usage.get(target_replica_id, 0) + tokens_required
+                self._replica_token_usage[target_replica.replica_id] = (
+                    self._replica_token_usage.get(target_replica.replica_id, 0) + tokens_required
                 )
                 self._request_at_replica[request_id] = (
-                    target_replica_id,
+                    target_replica.replica_id,
                     tokens_required,
                 )
                 self._budgeted_requests.add(request_id)
                 print(
                     f"[BUDGET] Admission committed for req={request_id} "
-                    f"to replica={target_replica_id} "
-                    f"(Usage: {self._replica_token_usage[target_replica_id]})"
+                    f"to replica={target_replica.replica_id} "
+                    f"(Usage: {self._replica_token_usage[target_replica.replica_id]})"
                 )
 
             return [[target_replica]]  # noqa: TRY300

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -125,8 +125,6 @@ class IGWRouter(RequestRouter):
     def _get_rollout_request_id(self, body: Any) -> tuple[str, int]:
         """Generates a rollout request ID and approximate character length from the request body.
         We don't require character length to be accurate, it is used as a fail-safe and for edge cases.
-        rollout_request_id -> id used to track ISL/OSL of a single prompt across rollouts/steps. Calculated using promptIDs
-        request_id -> id used to uniquely identify a request (vLLM encourages this). 
         """
         if not body:
             return "", 0
@@ -181,6 +179,63 @@ class IGWRouter(RequestRouter):
                     res.append(r)
         return res
 
+    def _token_budget_needed(self, request_id: str | None, fc: dict) -> bool:
+        """Decide if this request requires token budgeting."""
+        use_token_budget = fc.get("use_token_budget", _DEFAULT_USE_TOKEN_BUDGET)
+        return (
+            use_token_budget and request_id and request_id not in self._budgeted_requests
+        )
+
+    def _estimate_tokens_required(self, rollout_id: str, char_len: int, fc: dict) -> int:
+        """Estimate the tokens required for this request."""
+        stats = self._rollout_request_stats.get(rollout_id)
+        if stats:
+            return stats["isl"] + stats["osl"]
+
+        # Fallback for first contact with prompt
+        default_osl = fc.get("default_osl", 1024)
+        return (char_len // 4) + default_osl
+
+    def _maybe_drip(
+        self, replicas: list[RunningReplica], stats: list[dict], fc: dict
+    ) -> RunningReplica | None:
+        """Check if any replica qualifies for drip admission."""
+        now = time.time()
+        drip_interval_s = fc.get("drip_interval_s", 2.0)
+        if (now - self._last_drip_at) < drip_interval_s:
+            return None
+
+        drip_threshold_kv = fc.get("drip_threshold_kv", 0.1)
+        for i, r in enumerate(replicas):
+            physical_kv = stats[i].get("kv", 1.0)
+            if physical_kv < drip_threshold_kv:
+                self._last_drip_at = now
+                print(
+                    f"[BUDGET] Drip Admission to {r.replica_id} (Physical KV: {physical_kv:.2f})"
+                )
+                return r
+        return None
+
+    async def _wait_for_admission(
+        self,
+        replicas: list[RunningReplica],
+        tokens: int,
+        pending_request: PendingRequest,
+        fc: dict,
+    ) -> list[RunningReplica]:
+        """Wait loop until replicas are available or a drip admission occurs."""
+        while True:
+            available = self._get_available_replicas(replicas, tokens)
+            if available:
+                return available
+
+            new_stats = await self._get_routing_stats(replicas, pending_request)
+            drip_replica = self._maybe_drip(replicas, new_stats, fc)
+            if drip_replica:
+                return [drip_replica]
+
+            await self._wait_for_space()
+
     async def choose_replicas(  # noqa: PLR0912
         self,
         candidate_replicas: list[RunningReplica],
@@ -197,8 +252,7 @@ class IGWRouter(RequestRouter):
         request_id = llm_req.request_id
 
         # for health check empty requests
-        if char_len == 0:
-            print("No pending request or args, defaulting to random choice")
+        if not pending_request or not pending_request.args or char_len == 0:
             index = random.randint(0, len(candidate_replicas) - 1)
             return [[candidate_replicas[index]]]
 
@@ -208,18 +262,19 @@ class IGWRouter(RequestRouter):
             candidates = []
             for replica, routing_stats in zip(candidate_replicas, metrics_results):
                 queue_len = 0
+                replica_id = replica.replica_id
                 if self.replica_queue_len_cache:
-                    cached_val = self.replica_queue_len_cache.get(replica.replica_id)
+                    cached_val = self.replica_queue_len_cache.get(replica_id)
                     if cached_val is not None:
                         queue_len = cached_val
 
                 # Discover and cache KV Cache size if not already known
-                if replica.replica_id not in self._replica_kv_cache_size:
+                if replica_id not in self._replica_kv_cache_size:
                     kv_cache_size = routing_stats.get("kv_cache_size", -1)
                     if kv_cache_size > 0:
-                        self._replica_kv_cache_size[replica.replica_id] = kv_cache_size
+                        self._replica_kv_cache_size[replica_id] = kv_cache_size
                         print(
-                            f"[BUDGET] Discovered KV Cache size for replica {replica.replica_id}: {kv_cache_size} tokens"
+                            f"[BUDGET] Discovered KV Cache size for replica {replica_id}: {kv_cache_size} tokens"
                         )
 
                 if isinstance(routing_stats, Exception):
@@ -237,78 +292,23 @@ class IGWRouter(RequestRouter):
                 )
 
             fc = self.scheduler.get_flow_control_config()
-            use_token_budget = fc.get("use_token_budget", _DEFAULT_USE_TOKEN_BUDGET)
-
             tokens_required = 0
             is_budgeted = False
 
-            if (
-                use_token_budget
-                and request_id
-                and request_id not in self._budgeted_requests
-            ):
-                default_osl = fc.get("default_osl", 1024)
-                drip_threshold_kv = fc.get("drip_threshold_kv", 0.1)
-                drip_interval_s = fc.get("drip_interval_s", 2.0)
-                stats = self._rollout_request_stats.get(rollout_request_id)
+            if self._token_budget_needed(request_id, fc):
+                tokens_required = self._estimate_tokens_required(
+                    rollout_request_id, char_len, fc
+                )
+                candidate_replicas = await self._wait_for_admission(
+                    candidate_replicas, tokens_required, pending_request, fc
+                )
+                is_budgeted = True
 
-                if stats:
-                    tokens_required = stats["isl"] + stats["osl"]
-                    is_budgeted = True
-                else:
-                    # Fallback for first contact with prompt
-                    tokens_required = (char_len // 4) + default_osl
-                    is_budgeted = True
+                # Sync scheduler candidates with available replicas
+                available_replica_ids = {str(r.replica_id) for r in candidate_replicas}
+                candidates = [c for c in candidates if c.name in available_replica_ids]
 
-                if is_budgeted:
-                    while True:
-                        available_replicas = self._get_available_replicas(
-                            candidate_replicas, tokens_required
-                        )
-
-                        if available_replicas:
-                            candidate_replicas = available_replicas
-                            candidates = [
-                                c
-                                for c in candidates
-                                if c.name in [str(r.replica_id) for r in candidate_replicas]
-                            ]
-                            break
-                        else:
-                            new_metrics = await self._get_routing_stats(
-                                candidate_replicas, pending_request
-                            )
-                            for i, res in enumerate(new_metrics):
-                                candidates[i].attributes["routing_stats"] = res
-
-                            now = time.time()
-                            best_drip_replica = None
-                            for i, r in enumerate(candidate_replicas):
-                                stats = candidates[i].attributes.get("routing_stats", {})
-                                physical_kv = stats.get("kv", 1.0)
-
-                                if (
-                                    physical_kv < drip_threshold_kv
-                                    and (now - self._last_drip_at) > drip_interval_s
-                                ):
-                                    best_drip_replica = r
-                                    break
-
-                            if best_drip_replica:
-                                self._last_drip_at = now
-                                print(
-                                    f"[BUDGET] Drip Admission: req={request_id} to {best_drip_replica.replica_id} (Physical KV: {physical_kv:.2f})"
-                                )
-                                candidate_replicas = [best_drip_replica]
-                                candidates = [
-                                    c
-                                    for c in candidates
-                                    if c.name == str(best_drip_replica.replica_id)
-                                ]
-                                is_budgeted = True
-                                break
-
-                        await self._wait_for_space()
+            self.scheduler._maybe_reload_config()
 
             selected_endpoints = self.scheduler.run(llm_req, candidates)
 
@@ -324,19 +324,20 @@ class IGWRouter(RequestRouter):
                 index = random.randint(0, len(candidate_replicas) - 1)
 
             target_replica = candidate_replicas[index]
+            target_replica_id = target_replica.replica_id
 
             # Commit the reservation for the selected replica
             if is_budgeted:
-                self._replica_token_usage[target_replica.replica_id] = (
-                    self._replica_token_usage.get(target_replica.replica_id, 0) + tokens_required
+                self._replica_token_usage[target_replica_id] = (
+                    self._replica_token_usage.get(target_replica_id, 0) + tokens_required
                 )
                 self._request_at_replica[request_id] = (
-                    target_replica.replica_id,
+                    target_replica_id,
                     tokens_required,
                 )
                 self._budgeted_requests.add(request_id)
                 print(
-                    f"[BUDGET] Admission committed for req={request_id} to replica={target_replica.replica_id} (Usage: {self._replica_token_usage[target_replica.replica_id]})"
+                    f"[BUDGET] Admission committed for req={request_id} to replica={target_replica_id} (Usage: {self._replica_token_usage[target_replica_id]})"
                 )
 
             return [[target_replica]]

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -234,7 +234,7 @@ class IGWRouter(RequestRouter):
 
             await self._wait_for_space()
 
-    async def choose_replicas(  # noqa: PLR0912, PLR0914, C901, PLR0915
+    async def choose_replicas(  # noqa: PLR0912, PLR0914, C901
         self,
         candidate_replicas: list[RunningReplica],
         pending_request: PendingRequest | None = None,
@@ -305,9 +305,6 @@ class IGWRouter(RequestRouter):
                 # Sync scheduler candidates with available replicas
                 available_replica_ids = {str(r.replica_id) for r in candidate_replicas}
                 candidates = [c for c in candidates if c.name in available_replica_ids]
-
-            self.scheduler._maybe_reload_config()
-
             selected_endpoints = self.scheduler.run(llm_req, candidates)
 
             index = -1

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -208,19 +208,18 @@ class IGWRouter(RequestRouter):
             candidates = []
             for replica, routing_stats in zip(candidate_replicas, metrics_results):
                 queue_len = 0
-                replica_id = replica.replica_id
                 if self.replica_queue_len_cache:
-                    cached_val = self.replica_queue_len_cache.get(replica_id)
+                    cached_val = self.replica_queue_len_cache.get(replica.replica_id)
                     if cached_val is not None:
                         queue_len = cached_val
 
                 # Discover and cache KV Cache size if not already known
-                if replica_id not in self._replica_kv_cache_size:
+                if replica.replica_id not in self._replica_kv_cache_size:
                     kv_cache_size = routing_stats.get("kv_cache_size", -1)
                     if kv_cache_size > 0:
-                        self._replica_kv_cache_size[replica_id] = kv_cache_size
+                        self._replica_kv_cache_size[replica.replica_id] = kv_cache_size
                         print(
-                            f"[BUDGET] Discovered KV Cache size for replica {replica_id}: {kv_cache_size} tokens"
+                            f"[BUDGET] Discovered KV Cache size for replica {replica.replica_id}: {kv_cache_size} tokens"
                         )
 
                 if isinstance(routing_stats, Exception):
@@ -325,20 +324,19 @@ class IGWRouter(RequestRouter):
                 index = random.randint(0, len(candidate_replicas) - 1)
 
             target_replica = candidate_replicas[index]
-            target_replica_id = target_replica.replica_id
 
             # Commit the reservation for the selected replica
             if is_budgeted:
-                self._replica_token_usage[target_replica_id] = (
-                    self._replica_token_usage.get(target_replica_id, 0) + tokens_required
+                self._replica_token_usage[target_replica.replica_id] = (
+                    self._replica_token_usage.get(target_replica.replica_id, 0) + tokens_required
                 )
                 self._request_at_replica[request_id] = (
-                    target_replica_id,
+                    target_replica.replica_id,
                     tokens_required,
                 )
                 self._budgeted_requests.add(request_id)
                 print(
-                    f"[BUDGET] Admission committed for req={request_id} to replica={target_replica_id} (Usage: {self._replica_token_usage[target_replica_id]})"
+                    f"[BUDGET] Admission committed for req={request_id} to replica={target_replica.replica_id} (Usage: {self._replica_token_usage[target_replica.replica_id]})"
                 )
 
             return [[target_replica]]

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -125,6 +125,8 @@ class IGWRouter(RequestRouter):
     def _get_rollout_request_id(self, body: Any) -> tuple[str, int]:
         """Generates a rollout request ID and approximate character length from the request body.
         We don't require character length to be accurate, it is used as a fail-safe and for edge cases.
+        rollout_request_id -> id used to track ISL/OSL of a single prompt across rollouts/steps. Calculated using promptIDs
+        request_id -> id used to uniquely identify a request (vLLM encourages this). 
         """
         if not body:
             return "", 0
@@ -195,7 +197,8 @@ class IGWRouter(RequestRouter):
         request_id = llm_req.request_id
 
         # for health check empty requests
-        if not pending_request or not pending_request.args or char_len == 0:
+        if char_len == 0:
+            print("No pending request or args, defaulting to random choice")
             index = random.randint(0, len(candidate_replicas) - 1)
             return [[candidate_replicas[index]]]
 
@@ -307,8 +310,6 @@ class IGWRouter(RequestRouter):
                                 break
 
                         await self._wait_for_space()
-
-            self.scheduler._maybe_reload_config()
 
             selected_endpoints = self.scheduler.run(llm_req, candidates)
 

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -108,9 +108,7 @@ class IGWRouter(RequestRouter):
 
         if not pending_request or not pending_request.args:
             print("No pending request or args, defaulting to random choice")
-            return LLMRequest(
-                request_id=req_id, body="", target_model=self.deployment_name
-            )
+            return LLMRequest(request_id=req_id, body="", target_model=self.deployment_name)
         request_args = pending_request.args[0]
 
         if hasattr(request_args, "messages"):
@@ -175,9 +173,10 @@ class IGWRouter(RequestRouter):
         res = []
         for r in candidate_replicas:
             budget = self._replica_kv_cache_size.get(r.replica_id)
-            if budget is not None and budget > 0 and (
-                self._replica_token_usage.get(r.replica_id, 0) + tokens_required
-                <= budget
+            if (
+                budget is not None
+                and budget > 0
+                and (self._replica_token_usage.get(r.replica_id, 0) + tokens_required <= budget)
             ):
                 res.append(r)
         return res
@@ -185,9 +184,7 @@ class IGWRouter(RequestRouter):
     def _token_budget_needed(self, request_id: str | None, fc: dict) -> bool:
         """Decide if this request requires token budgeting."""
         use_token_budget = fc.get("use_token_budget", _DEFAULT_USE_TOKEN_BUDGET)
-        return (
-            use_token_budget and request_id and request_id not in self._budgeted_requests
-        )
+        return use_token_budget and request_id and request_id not in self._budgeted_requests
 
     def _estimate_tokens_required(self, rollout_id: str, char_len: int, fc: dict) -> int:
         """Estimate the tokens required for this request."""
@@ -213,9 +210,7 @@ class IGWRouter(RequestRouter):
             physical_kv = stats[i].get("kv", 1.0)
             if physical_kv < drip_threshold_kv:
                 self._last_drip_at = now
-                print(
-                    f"[BUDGET] Drip Admission to {r.replica_id} (Physical KV: {physical_kv:.2f})"
-                )
+                print(f"[BUDGET] Drip Admission to {r.replica_id} (Physical KV: {physical_kv:.2f})")
                 return r
         return None
 
@@ -281,7 +276,9 @@ class IGWRouter(RequestRouter):
                         )
 
                 if isinstance(routing_stats, Exception):
-                    print(f"Failed to fetch metrics via RPC for {replica.replica_id}: {routing_stats}")
+                    print(
+                        f"Failed to fetch metrics via RPC for {replica.replica_id}: {routing_stats}"
+                    )
                     routing_stats = {}  # noqa: PLW2901
 
                 candidates.append(
@@ -299,9 +296,7 @@ class IGWRouter(RequestRouter):
             is_budgeted = False
 
             if self._token_budget_needed(request_id, fc):
-                tokens_required = self._estimate_tokens_required(
-                    rollout_request_id, char_len, fc
-                )
+                tokens_required = self._estimate_tokens_required(rollout_request_id, char_len, fc)
                 candidate_replicas = await self._wait_for_admission(
                     candidate_replicas, tokens_required, pending_request, fc
                 )
@@ -470,11 +465,9 @@ def build_custom_openai_app(builder_config: dict[str, object]) -> object:
     ).bind(llm_deployments=llm_deployments, **ingress_cls_config.ingress_extra_kwargs)
 
 
-app = build_custom_openai_app(
-    {
-        "llm_configs": [llm_config],
-    }
-)
+app = build_custom_openai_app({
+    "llm_configs": [llm_config],
+})
 
 if __name__ == "__main__":
     serve.run(app, blocking=True)

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -79,12 +79,18 @@ class IGWRouter(RequestRouter):
         )
         self.scheduler = Scheduler()
         self.deployment_name = deployment_id.name
+
         # rollout_request_id -> {isl, max_osl}
         self._rollout_request_stats: dict[str, dict[str, int]] = {}
-        self._replica_token_usage: dict[ReplicaID, int] = {}  # replica_id -> token_usage_at_replica
+
+        # replica_id -> token_usage_at_replica
+        self._replica_token_usage: dict[ReplicaID, int] = {}
+
         # request_id -> (replica_id, tokens)
         self._request_at_replica: dict[str, tuple[ReplicaID, int]] = {}
-        self._admission_queue: list[asyncio.Future] = []  # FIFO queue for blocked requests
+
+        # FIFO queue for blocked requests
+        self._admission_queue: list[asyncio.Future] = []
 
         self._last_drip_at = 0.0
         self._loop: asyncio.AbstractEventLoop | None = None

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -106,7 +106,7 @@ class IGWRouter(RequestRouter):
             for r in replicas
         ]
         results = await asyncio.gather(*futures, return_exceptions=True)
-        return [res if not isinstance(res, Exception) else {} for res in results]
+        return [res if not isinstance(res, BaseException) else {} for res in results]
 
     def _parse_to_llm_request(self, pending_request: PendingRequest) -> LLMRequest:
         """Converts Ray request to LLMRequest."""
@@ -166,6 +166,8 @@ class IGWRouter(RequestRouter):
 
     async def _wait_for_space(self) -> None:
         """Wait until at least one replica has space freed up."""
+        if self._loop is None:
+            raise RuntimeError("Event loop is not initialized")
         fut = self._loop.create_future()
         self._admission_queue.append(fut)
         await fut
@@ -190,7 +192,7 @@ class IGWRouter(RequestRouter):
     def _token_budget_needed(self, request_id: str | None, fc: dict) -> bool:
         """Decide if this request requires token budgeting."""
         use_token_budget = fc.get("use_token_budget", _DEFAULT_USE_TOKEN_BUDGET)
-        return use_token_budget and request_id and request_id not in self._budgeted_requests
+        return bool(use_token_budget and request_id and request_id not in self._budgeted_requests)
 
     def _estimate_tokens_required(self, rollout_id: str, char_len: int, fc: dict) -> int:
         """Estimate the tokens required for this request."""
@@ -199,7 +201,7 @@ class IGWRouter(RequestRouter):
             return stats["isl"] + stats["osl"]
 
         # Fallback for first contact with prompt
-        default_osl = fc.get("default_osl", 1024)
+        default_osl: int = fc.get("default_osl", 1024)
         return (char_len // 4) + default_osl
 
     def _maybe_drip(
@@ -451,14 +453,14 @@ llm_config = LLMConfig(
 
 def build_custom_openai_app(builder_config: dict[str, object]) -> object:
     # Same internal logic as build_openai_app, but we map our deployment_cls
-    builder_config = LLMServingArgs.model_validate(builder_config)
-    llm_configs = builder_config.llm_configs
+    builder_args = LLMServingArgs.model_validate(builder_config)
+    llm_configs = builder_args.llm_configs
 
     llm_deployments = [
         build_llm_deployment(c, deployment_cls=MetricsAwareLLMServer) for c in llm_configs
     ]
 
-    ingress_cls_config = builder_config.ingress_cls_config
+    ingress_cls_config = builder_args.ingress_cls_config
     ingress_options = ingress_cls_config.ingress_cls.get_deployment_options(llm_configs)
     ingress_cls = make_fastapi_ingress(ingress_cls_config.ingress_cls)
 

--- a/scheduling/core/config.py
+++ b/scheduling/core/config.py
@@ -62,13 +62,12 @@ class SchedulerConfig:
 
         profiles_dict = config_dict.get("profiles")
         if not profiles_dict:
-            raise ValueError(
-                "Scheduler configuration must include a 'profiles' dictionary."
-            )
+            raise ValueError("Scheduler configuration must include a 'profiles' dictionary.")
 
         parsed_profiles: dict[str, SchedulerProfile] = {}
         for profile_name, prof_data in profiles_dict.items():
             profile = SchedulerProfile(name=profile_name)
+            profile.flow_control = prof_data.get("flow_control", {})
 
             for filter_config in prof_data.get("filters", []):
                 cfg = dict(filter_config)
@@ -81,9 +80,7 @@ class SchedulerConfig:
                 s_type = cfg.pop("type")
                 weight = cfg.pop("weight", 1.0)
                 s_instance = build_scorer(s_type, **cfg)
-                profile.with_scorers(
-                    WeightedScorer(scorer=s_instance, weight=float(weight))
-                )
+                profile.with_scorers(WeightedScorer(scorer=s_instance, weight=float(weight)))
 
             picker_config = prof_data.get("picker")
             if picker_config:

--- a/scheduling/core/scheduler.py
+++ b/scheduling/core/scheduler.py
@@ -55,6 +55,7 @@ class Scheduler:
 
     def get_flow_control_config(self) -> dict[str, Any]:
         """Returns the flow_control configuration from the primary profile, or an empty dict."""
+        self._maybe_reload_config()
         if hasattr(self, "profiles") and self.profiles:
             primary_profile = next(iter(self.profiles.values()))
             return getattr(primary_profile, "flow_control", {})
@@ -127,3 +128,16 @@ class Scheduler:
             result.metadata = res.metadata
 
         return result
+
+    def run(
+        self, request: LLMRequest, candidates: Sequence[Endpoint]
+    ) -> Sequence[ScoredEndpoint]:
+        scheduler_output = self.schedule(request, candidates)
+        profile_name = scheduler_output.selected_profile
+        profile_results = scheduler_output.profile_results.get(profile_name)
+
+        print(f"Profile {profile_name} results: {profile_results}")
+        if profile_results and profile_results.endpoint:
+            return [profile_results.endpoint]
+        print("No endpoint selected, defaulting to framework routing logic")
+        return []

--- a/scheduling/core/scheduler.py
+++ b/scheduling/core/scheduler.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import os
 import pathlib
-from typing import Sequence
+from typing import Any, Sequence
 
 import yaml
 
@@ -33,29 +33,32 @@ from scheduling.framework import (
 
 
 class Scheduler:
-    def __init__(self, config_path: str | None = None) -> None:
-        if config_path:
-            self.config_path = config_path
-        else:
-            self.config_path = os.environ.get("ROUTER_CONFIG_PATH")
-            if not self.config_path:
-                raise ValueError(
-                    "ROUTER_CONFIG_PATH environment variable is missing and no "
-                    "config_path provided. Ensure the ConfigMap is mounted or "
-                    "path is passed."
-                )
-
+    def __init__(self):
+        self.profiles = {}
+        self.profile_handler = None
+        self.config_path = None
         self.last_mtime = 0
-        self._maybe_reload_config()
 
     @classmethod
-    def new_with_config(cls, config: SchedulerConfig) -> Scheduler:
-        instance = object.__new__(cls)
-        instance.config_path = None
-        instance.last_mtime = 0
+    def from_config(cls, config_path: str) -> "Scheduler":
+        instance = cls()
+        instance.config_path = config_path
+        instance._maybe_reload_config()
+        return instance
+
+    @classmethod
+    def from_object(cls, config: SchedulerConfig) -> "Scheduler":
+        instance = cls()
         instance.profile_handler = config.profile_handler
         instance.profiles = config.profiles
         return instance
+
+    def get_flow_control_config(self) -> dict[str, Any]:
+        """Returns the flow_control configuration from the primary profile, or an empty dict."""
+        if hasattr(self, "profiles") and self.profiles:
+            primary_profile = next(iter(self.profiles.values()))
+            return getattr(primary_profile, "flow_control", {})
+        return {}
 
     def _maybe_reload_config(self) -> None:
         if self.config_path is None:
@@ -106,35 +109,21 @@ class Scheduler:
 
         # Build SchedulingResult
         result = SchedulingResult(
-            profile_results={
-                k: v or ProfileRunResult() for k, v in profile_results.items()
-            },
-            primary_profile_name=primary,
+            request=request,
+            profile_results=profile_results,
+            selected_profile=primary,
         )
-        selected_eps = (
-            result.profile_results[primary].endpoint_list[:1]
-            if primary in result.profile_results
-            else []
-        )
-        print(f"Selected endpoint {selected_eps}")
-        if selected_eps:
-            for w in self.profiles[primary].scorers:
-                if hasattr(w.scorer, "pre_request"):
-                    w.scorer.pre_request(cycle_state, request, selected_eps[0].endpoint)
+
+        # update scores on candidates
+        if primary and profile_results.get(primary):
+            res = profile_results[primary]
+            # update candidate scores
+            for ep in candidates:
+                if ep.name in res.scores:
+                    ep.score = res.scores[ep.name]
+                else:
+                    ep.score = 0.0
+            result.endpoint = res.endpoint
+            result.metadata = res.metadata
+
         return result
-
-    def run(
-        self, request: LLMRequest, candidates: Sequence[Endpoint]
-    ) -> Sequence[ScoredEndpoint]:
-        self._maybe_reload_config()
-        scheduler_output = self.schedule(request, candidates)
-        profile_name = scheduler_output.primary_profile_name
-        profile_results = scheduler_output.profile_results.get(profile_name)
-
-        print(f"Profile {profile_name} results: {profile_results}")
-        selected_endpoint = profile_results.endpoint_list[:1]
-
-        if len(selected_endpoint) > 0:
-            return selected_endpoint  # pick top 1
-        print("No endpoint selected, defaulting to framework routing logic")
-        return []

--- a/scheduling/core/scheduler.py
+++ b/scheduling/core/scheduler.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import os
 import pathlib
 from typing import Any, Sequence
 
@@ -33,21 +32,21 @@ from scheduling.framework import (
 
 
 class Scheduler:
-    def __init__(self):
+    def __init__(self) -> None:
         self.profiles = {}
         self.profile_handler = None
         self.config_path = None
         self.last_mtime = 0
 
     @classmethod
-    def from_config(cls, config_path: str) -> "Scheduler":
+    def from_config(cls, config_path: str) -> Scheduler:
         instance = cls()
         instance.config_path = config_path
         instance._maybe_reload_config()
         return instance
 
     @classmethod
-    def from_object(cls, config: SchedulerConfig) -> "Scheduler":
+    def new_with_config(cls, config: SchedulerConfig) -> Scheduler:
         instance = cls()
         instance.profile_handler = config.profile_handler
         instance.profiles = config.profiles
@@ -110,22 +109,20 @@ class Scheduler:
 
         # Build SchedulingResult
         result = SchedulingResult(
-            request=request,
-            profile_results=profile_results,
-            selected_profile=primary,
+            profile_results={k: v or ProfileRunResult() for k, v in profile_results.items()},
+            primary_profile_name=primary,
         )
 
-        # update scores on candidates
-        if primary and profile_results.get(primary):
-            res = profile_results[primary]
-            # update candidate scores
-            for ep in candidates:
-                if ep.name in res.scores:
-                    ep.score = res.scores[ep.name]
-                else:
-                    ep.score = 0.0
-            result.endpoint = res.endpoint
-            result.metadata = res.metadata
+        selected_eps = (
+            result.profile_results[primary].endpoint_list[:1]
+            if primary in result.profile_results
+            else []
+        )
+        print(f"Selected endpoint {selected_eps}")
+        if selected_eps:
+            for w in self.profiles[primary].scorers:
+                if hasattr(w.scorer, "pre_request"):
+                    w.scorer.pre_request(cycle_state, request, selected_eps[0].endpoint)
 
         return result
 
@@ -133,11 +130,11 @@ class Scheduler:
         self, request: LLMRequest, candidates: Sequence[Endpoint]
     ) -> Sequence[ScoredEndpoint]:
         scheduler_output = self.schedule(request, candidates)
-        profile_name = scheduler_output.selected_profile
+        profile_name = scheduler_output.primary_profile_name
         profile_results = scheduler_output.profile_results.get(profile_name)
 
         print(f"Profile {profile_name} results: {profile_results}")
-        if profile_results and profile_results.endpoint:
-            return [profile_results.endpoint]
+        if profile_results and profile_results.endpoint_list:
+            return profile_results.endpoint_list[:1]
         print("No endpoint selected, defaulting to framework routing logic")
         return []

--- a/scheduling/framework/interface.py
+++ b/scheduling/framework/interface.py
@@ -15,30 +15,36 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Mapping, Protocol, Sequence
+from typing import Any, Mapping, Protocol, Sequence
 
 from .types import CycleState, Endpoint, LLMRequest, ProfileRunResult, ScoredEndpoint
 
 
 class FilterPlugin(Protocol):
     def filter(
-        self, cycle_state: CycleState, request: LLMRequest, pods: Mapping[str, Endpoint]
-    ) -> Mapping[str, Endpoint]: ...
+        self,
+        request: LLMRequest,
+        cycle_state: CycleState,
+        endpoints: Sequence[Endpoint],
+    ) -> Sequence[Endpoint]:
+        ...
 
 
 class ScorerPlugin(Protocol):
     def score(
-        self, cycle_state: CycleState, request: LLMRequest, pods: Mapping[str, Endpoint]
-    ) -> dict[str, float]: ...
+        self, request: LLMRequest, endpoints: Sequence[Endpoint]
+    ) -> Mapping[str, float]:
+        ...
 
 
 class PickerPlugin(Protocol):
     def pick(
         self,
-        cycle_state: CycleState,
         request: LLMRequest,
-        scored_pods: Sequence[ScoredEndpoint],
-    ) -> ScoredEndpoint | None: ...
+        cycle_state: CycleState,
+        endpoints: Sequence[ScoredEndpoint],
+    ) -> ScoredEndpoint | None:
+        ...
 
 
 class ProfileHandler(Protocol):
@@ -46,16 +52,18 @@ class ProfileHandler(Protocol):
         self,
         cycle_state: CycleState,
         request: LLMRequest,
-        profiles: dict[str, SchedulerProfile],
-        profile_results: dict[str, ProfileRunResult | None],
-    ) -> dict[str, SchedulerProfile]: ...
+        profiles: Mapping[str, SchedulerProfile],
+        profile_results: Mapping[str, ProfileRunResult | None],
+    ) -> Mapping[str, SchedulerProfile]:
+        ...
 
     def process_results(
         self,
         cycle_state: CycleState,
         request: LLMRequest,
-        profile_results: dict[str, ProfileRunResult | None],
-    ) -> str | None: ...
+        profile_results: Mapping[str, ProfileRunResult | None],
+    ) -> str | None:
+        ...
 
 
 @dataclass
@@ -70,6 +78,7 @@ class SchedulerProfile:
     filters: list[FilterPlugin] = field(default_factory=list)
     scorers: list[WeightedScorer] = field(default_factory=list)
     picker: PickerPlugin | None = None
+    flow_control: dict[str, Any] = field(default_factory=dict)
 
     def with_filters(self, *fs: FilterPlugin) -> SchedulerProfile:
         self.filters.extend(fs)
@@ -87,38 +96,24 @@ class SchedulerProfile:
         self,
         request: LLMRequest,
         cycle_state: CycleState,
-        candidates: Sequence[Endpoint],
+        endpoints: Sequence[Endpoint],
     ) -> ProfileRunResult:
-        # normalize candidates into a mapping name->Endpoint
-        endpoints_map: dict[str, Endpoint] = {e.name: e for e in candidates}
-
-        # run filters: each filter returns a mapping of name->Endpoint
+        # 1. run filters
+        filtered = endpoints
         for f in self.filters:
-            endpoints_map = dict(f.filter(cycle_state, request, endpoints_map))
+            filtered = f.filter(request, cycle_state, filtered)
 
-        # if no endpoints left, return empty result
-        if not endpoints_map:
-            return ProfileRunResult()
+        # map to quickly find endpoints by name
+        endpoints_map = {e.name: e for e in endpoints}
 
-        # combine scores (score plugins return name->float)
-        total_scores: dict[str, float] = dict.fromkeys(endpoints_map.keys(), 0.0)
-        for w in self.scorers:
-            raw_sc = w.scorer.score(cycle_state, request, endpoints_map)
-            print(f"Scorer {w.scorer} raw scores: {raw_sc}")
-            # normalize raw_sc values to [0,1] across endpoints present in endpoints_map
-            vals = [float(raw_sc.get(name, 0.0)) for name in endpoints_map]
-            if vals:
-                min_v = min(vals)
-                max_v = max(vals)
-                if max_v > min_v:
-                    for name in endpoints_map:
-                        v = float(raw_sc.get(name, 0.0))
-                        norm = (v - min_v) / (max_v - min_v)
-                        total_scores[name] += norm * w.weight
-                else:
-                    # all values equal -> give full score to all
-                    for name in endpoints_map:
-                        total_scores[name] += 1.0 * w.weight
+        # 2. run scorers
+        total_scores = {}
+        for ws in self.scorers:
+            scores = ws.scorer.score(request, filtered)
+            for name, score in scores.items():
+                total_scores[name] = (
+                    total_scores.get(name, 0.0) + score * ws.weight
+                )
 
         # create ScoredEndpoint list preserving endpoint info
         scored = [
@@ -130,13 +125,12 @@ class SchedulerProfile:
         # sort descending
         scored.sort(key=lambda sp: sp.score, reverse=True)
 
-        chosen = []
-        if self.picker is not None:
-            picked = self.picker.pick(cycle_state, request, scored)
-            if picked is not None:
-                chosen = [picked]
-        # default: take highest-scoring endpoint
-        elif scored:
-            chosen = [scored[0]]
+        # 3. run picker
+        if self.picker and len(scored) > 0:
+            picked = self.picker.pick(request, cycle_state, scored)
+        else:
+            picked = scored[0] if len(scored) > 0 else None
 
-        return ProfileRunResult(endpoint_list=chosen)
+        return ProfileRunResult(
+            profile_name=self.name, scores=total_scores, endpoint=picked
+        )

--- a/scheduling/framework/interface.py
+++ b/scheduling/framework/interface.py
@@ -22,29 +22,23 @@ from .types import CycleState, Endpoint, LLMRequest, ProfileRunResult, ScoredEnd
 
 class FilterPlugin(Protocol):
     def filter(
-        self,
-        request: LLMRequest,
-        cycle_state: CycleState,
-        endpoints: Sequence[Endpoint],
-    ) -> Sequence[Endpoint]:
-        ...
+        self, cycle_state: CycleState, request: LLMRequest, pods: Mapping[str, Endpoint]
+    ) -> Mapping[str, Endpoint]: ...
 
 
 class ScorerPlugin(Protocol):
     def score(
-        self, request: LLMRequest, endpoints: Sequence[Endpoint]
-    ) -> Mapping[str, float]:
-        ...
+        self, cycle_state: CycleState, request: LLMRequest, pods: Mapping[str, Endpoint]
+    ) -> dict[str, float]: ...
 
 
 class PickerPlugin(Protocol):
     def pick(
         self,
-        request: LLMRequest,
         cycle_state: CycleState,
-        endpoints: Sequence[ScoredEndpoint],
-    ) -> ScoredEndpoint | None:
-        ...
+        request: LLMRequest,
+        scored_pods: Sequence[ScoredEndpoint],
+    ) -> ScoredEndpoint | None: ...
 
 
 class ProfileHandler(Protocol):
@@ -52,18 +46,16 @@ class ProfileHandler(Protocol):
         self,
         cycle_state: CycleState,
         request: LLMRequest,
-        profiles: Mapping[str, SchedulerProfile],
-        profile_results: Mapping[str, ProfileRunResult | None],
-    ) -> Mapping[str, SchedulerProfile]:
-        ...
+        profiles: dict[str, SchedulerProfile],
+        profile_results: dict[str, ProfileRunResult | None],
+    ) -> dict[str, SchedulerProfile]: ...
 
     def process_results(
         self,
         cycle_state: CycleState,
         request: LLMRequest,
-        profile_results: Mapping[str, ProfileRunResult | None],
-    ) -> str | None:
-        ...
+        profile_results: dict[str, ProfileRunResult | None],
+    ) -> str | None: ...
 
 
 @dataclass
@@ -96,24 +88,38 @@ class SchedulerProfile:
         self,
         request: LLMRequest,
         cycle_state: CycleState,
-        endpoints: Sequence[Endpoint],
+        candidates: Sequence[Endpoint],
     ) -> ProfileRunResult:
-        # 1. run filters
-        filtered = endpoints
+        # normalize candidates into a mapping name->Endpoint
+        endpoints_map: dict[str, Endpoint] = {e.name: e for e in candidates}
+
+        # run filters: each filter returns a mapping of name->Endpoint
         for f in self.filters:
-            filtered = f.filter(request, cycle_state, filtered)
+            endpoints_map = dict(f.filter(cycle_state, request, endpoints_map))
 
-        # map to quickly find endpoints by name
-        endpoints_map = {e.name: e for e in endpoints}
+        # if no endpoints left, return empty result
+        if not endpoints_map:
+            return ProfileRunResult()
 
-        # 2. run scorers
-        total_scores = {}
-        for ws in self.scorers:
-            scores = ws.scorer.score(request, filtered)
-            for name, score in scores.items():
-                total_scores[name] = (
-                    total_scores.get(name, 0.0) + score * ws.weight
-                )
+        # combine scores (score plugins return name->float)
+        total_scores: dict[str, float] = dict.fromkeys(endpoints_map.keys(), 0.0)
+        for w in self.scorers:
+            raw_sc = w.scorer.score(cycle_state, request, endpoints_map)
+            print(f"Scorer {w.scorer} raw scores: {raw_sc}")
+            # normalize raw_sc values to [0,1] across endpoints present in endpoints_map
+            vals = [float(raw_sc.get(name, 0.0)) for name in endpoints_map]
+            if vals:
+                min_v = min(vals)
+                max_v = max(vals)
+                if max_v > min_v:
+                    for name in endpoints_map:
+                        v = float(raw_sc.get(name, 0.0))
+                        norm = (v - min_v) / (max_v - min_v)
+                        total_scores[name] += norm * w.weight
+                else:
+                    # all values equal -> give full score to all
+                    for name in endpoints_map:
+                        total_scores[name] += 1.0 * w.weight
 
         # create ScoredEndpoint list preserving endpoint info
         scored = [
@@ -125,12 +131,13 @@ class SchedulerProfile:
         # sort descending
         scored.sort(key=lambda sp: sp.score, reverse=True)
 
-        # 3. run picker
-        if self.picker and len(scored) > 0:
-            picked = self.picker.pick(request, cycle_state, scored)
-        else:
-            picked = scored[0] if len(scored) > 0 else None
+        chosen = []
+        if self.picker is not None:
+            picked = self.picker.pick(cycle_state, request, scored)
+            if picked is not None:
+                chosen = [picked]
+        # default: take highest-scoring endpoint
+        elif scored:
+            chosen = [scored[0]]
 
-        return ProfileRunResult(
-            profile_name=self.name, scores=total_scores, endpoint=picked
-        )
+        return ProfileRunResult(endpoint_list=chosen)


### PR DESCRIPTION
This feature implements the initial version of KV Cache saturation based flow control for a replica. It intends to maintain a virtual budget of KV Cache tokens per replica to ensure that only requests that will fit into a replica's KV Cache are allowed in, ensuring 0 preemptions.  The following is the summary of the changes made:
- ```configs/scheduler_config.yaml```:
    - Added a ```flow_control``` section to be able to enable and configure the flow control and drip functionality in the router. This will be changed in a future refactor where flow control will be its own plugin type.
- ```datalayer/rayserve/engine.py```:
    - Added hooks for ```num_preempted``` for logging/future back pressure control and ```kv_cache_size``` for automatic retrieval of KV Cache size per replica
- ```datalayer/verl/metrics.py```:
    - Linting change.
- ```docs/kv_saturation.md```:
    - Explains in more detail the method used to maintain KV Cache saturation without over saturating.   
- ```integration/rayserve/router.py```:
    - **Key file for all KV Saturation changes**
    - Stores a map of every prompt's ISL and OSL. This is learned by following a prompt every time it is seen till completion and storing the ISL and OSL. A prompt is followed across rollouts using the  ```rollout_request_id``` which is a uuid5 hash of the ```prompt_ids```. If a prompt has never been seen before, it uses the ```char_len``` and whatever the ```default_osl``` configured in ```configs/scheduler_config.yaml``` is.
    - Stores a map of each replica's current token usage (```_replica_token_usage```)  and ensures that this does not cross the ```_replica_kv_cache_size``` (obtained directly from vLLM). The router only accepts a new request to a replica if there is enough space in that replica to admit the new request. The new request, if seen before, has a memory cost of ```isl+osl```, otherwise its cost is ```(char_len // 4) + default_osl```.
    - Requests that can't yet be served are stored in an async queue called ```_admission_queue``` and considered the moment any replica has space available from completing a request.
    - There is also the ```drip``` functionality. To avoid huge drops in KV Cache utilization when batches of requests are completed together (read more in ```docs/kv_saturation.md```), we implement ```drip```. Whenever KV Cache utilization is below a certain level (defined in ```drip_threshold_kv```) but the replicas are full (```_replica_token_usage == _replica_kv_cache_size```), requests are submitted into the replicas at an interval of ```drip_interval_s``` until the KV Cache utilization crosses the threshold defined. This is done so that when a batch of requests complete together, there are still some requests occupying KV Cache and the usage doesn't immediately fall to near 0. This increases the average KV Cache utilization over a run without resulting in preemption (when used with care). This is an optional feature and it's enablement/disablement is specified in ```docs/kv_saturation.md```.
- ```integration/verl/verl_hook.py```:
    - Linting fixes
-  ```scheduling/core/config.py```:
    - Small change to incorporate parsing ```flow_control``` from  ```configs/scheduler_config.yaml```. Will be changed when  ```flow_control``` is its own plugin.
- ```scheduling/core/scheduler.py```
    - Small change to incorporate parsing ```flow_control``` from  ```configs/scheduler_config.yaml```. Will be removed when  ```flow_control``` is its own plugin.
-  ```scheduling/framework/interface.py```:
    - Small change to incorporate parsing ```flow_control``` from  ```configs/scheduler_config.yaml```. Will be changed when  ```flow_control``` is its own plugin.
- ```scheduling/plugins/__init__.py```
    - Linting fixes. Will be expanded when ```flow_control``` is its own plugin. 

**NOTE: This feature is only available in the Ray Serve implementation for now. The verl implementation will most likely occur after the ```flow_control``` is made into a plugin**