### PR TITLE
fix: pass in lru_capacity_per_server through PrefixCacheScorer init

### DIFF
--- a/scheduling/plugins/scorers/prefix_plugin.py
+++ b/scheduling/plugins/scorers/prefix_plugin.py
@@ -134,7 +134,7 @@ class PrefixCacheScorer:
     ) -> None:
         self.block_size = block_size
         self.max_prefix_blocks = max_prefix_blocks
-        self.indexer = PrefixIndexer()
+        self.indexer = PrefixIndexer(lru_capacity_per_server=lru_capacity_per_server)
 
     def score(
         self,


### PR DESCRIPTION
In the `PrefixCacheScorer` the `lru_capacity_per_server` init param was not being passed down to the `PrefixIndexer`