### PR TITLE
fix: normalize scorer protocol and enable mypy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,3 +13,29 @@ jobs:
     - uses: astral-sh/ruff-action@v4.0.0
       with:
         args: check
+
+  py-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+    - uses: actions/setup-python@v6.2.0
+      with:
+        python-version: "3.12"
+    - uses: astral-sh/setup-uv@v3
+    - name: Install dependencies
+      run: uv sync --all-groups
+    - name: Run mypy
+      run: uv run mypy scheduling datalayer integration tests
+
+  py-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+    - uses: actions/setup-python@v6.2.0
+      with:
+        python-version: "3.12"
+    - uses: astral-sh/setup-uv@v3
+    - name: Install dependencies
+      run: uv sync --all-groups
+    - name: Run pytest
+      run: uv run pytest

--- a/datalayer/rayserve/engine.py
+++ b/datalayer/rayserve/engine.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from ray.llm._internal.serve.core.server.llm_server import LLMServer  # noqa: PLC2701
 from ray.llm._internal.serve.engines.vllm.vllm_engine import VLLMEngine  # noqa: PLC2701
-from vllm.v1.metrics.loggers import StatLoggerBase
+from vllm.v1.metrics.loggers import StatLoggerBase  # type: ignore[import-not-found]
 
 
 class DirectKVCacheLogger(StatLoggerBase):
@@ -61,21 +61,21 @@ class MetricsAwareVLLMEngine(VLLMEngine):
             vllm_config: object, engine_idx: int = 0
         ) -> DirectKVCacheLogger:
             logger = DirectKVCacheLogger(vllm_config, engine_idx)
-            logger.target_dict = self.live_metrics
+            logger.target_dict = self.live_metrics  # type: ignore[assignment]
             return logger
 
         # Needed for injecting the logger
-        from vllm.v1.engine.async_llm import AsyncLLM
-        from vllm.v1.executor.abstract import Executor
+        from vllm.v1.engine.async_llm import AsyncLLM  # type: ignore[import-not-found]
+        from vllm.v1.executor.abstract import Executor  # type: ignore[import-not-found]
 
-        engine_config.parallel_config.placement_group = pg
+        engine_config.parallel_config.placement_group = pg  # type: ignore[attr-defined]
         executor_class = Executor.get_class(engine_config)
 
         # Return the engine client, passing the FACTORY instead of the instance
         return AsyncLLM(
             vllm_config=engine_config,
             executor_class=executor_class,
-            log_stats=not engine_args.disable_log_stats,
+            log_stats=not engine_args.disable_log_stats,  # type: ignore[attr-defined]
             stat_loggers=[logger_factory],
         )
 
@@ -92,4 +92,4 @@ class MetricsAwareLLMServer(LLMServer):
     _default_engine_cls = MetricsAwareVLLMEngine
 
     async def record_routing_stats(self) -> dict[str, object]:
-        return self.engine.record_routing_stats()
+        return self.engine.record_routing_stats()  # type: ignore[no-any-return]

--- a/datalayer/verl/metrics.py
+++ b/datalayer/verl/metrics.py
@@ -28,7 +28,7 @@ async def fetch_worker_metrics(ep: Endpoint, inflight_store: InflightStore) -> N
     if not actor:
         return
     try:
-        stats = await actor.get_routing_stats.remote()
+        stats = await actor.get_routing_stats.remote()  # type: ignore[attr-defined]
         if stats.get("error"):
             logger.error("RPC stats error for %s: %s", ep.name, stats["error"])
         local_inflight = inflight_store.get(ep.name)

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -179,14 +179,14 @@ class IGWRouter(RequestRouter):
 def build_custom_openai_app(builder_config: dict[str, object]) -> object:
     # Same internal logic as build_openai_app, but we map our deployment_cls
     builder_config = LLMServingArgs.model_validate(builder_config)
-    llm_configs = builder_config.llm_configs
+    llm_configs = builder_config.llm_configs  # type: ignore[attr-defined]
 
     llm_deployments = [
         build_llm_deployment(c, deployment_cls=MetricsAwareLLMServer)
         for c in llm_configs
     ]
 
-    ingress_cls_config = builder_config.ingress_cls_config
+    ingress_cls_config = builder_config.ingress_cls_config  # type: ignore[attr-defined]
     ingress_options = ingress_cls_config.ingress_cls.get_deployment_options(llm_configs)
     ingress_cls = make_fastapi_ingress(ingress_cls_config.ingress_cls)
     return serve.deployment(ingress_cls, **ingress_options).bind(

--- a/integration/verl/verl_hook.py
+++ b/integration/verl/verl_hook.py
@@ -25,7 +25,9 @@ from verl.experimental.agent_loop.agent_loop import (  # type: ignore[import-not
     AgentLoopWorker,
     AsyncLLMServerManager,
 )
-from verl.workers.rollout.vllm_rollout.vllm_async_server import vLLMHttpServer  # type: ignore[import-not-found]
+from verl.workers.rollout.vllm_rollout.vllm_async_server import (  # type: ignore[import-not-found]
+    vLLMHttpServer,  # type: ignore[import-not-found]
+)
 
 from datalayer.verl.datastore import InflightStore
 from datalayer.verl.metrics import verl_metrics_polling_loop

--- a/integration/verl/verl_hook.py
+++ b/integration/verl/verl_hook.py
@@ -19,13 +19,13 @@ import logging
 import uuid
 
 import ray
-from omegaconf import DictConfig
-from verl.experimental.agent_loop.agent_loop import (
+from omegaconf import DictConfig  # type: ignore[import-not-found]
+from verl.experimental.agent_loop.agent_loop import (  # type: ignore[import-not-found]
     AgentLoopManager,
     AgentLoopWorker,
     AsyncLLMServerManager,
 )
-from verl.workers.rollout.vllm_rollout.vllm_async_server import vLLMHttpServer
+from verl.workers.rollout.vllm_rollout.vllm_async_server import vLLMHttpServer  # type: ignore[import-not-found]
 
 from datalayer.verl.datastore import InflightStore
 from datalayer.verl.metrics import verl_metrics_polling_loop
@@ -96,13 +96,13 @@ class VllmEnginePatch:
     @classmethod
     def apply(cls) -> None:
         try:
-            from vllm.v1.engine.async_llm import AsyncLLM
-            from vllm.v1.metrics.loggers import StatLoggerManager
+            from vllm.v1.engine.async_llm import AsyncLLM  # type: ignore[import-not-found]
+            from vllm.v1.metrics.loggers import StatLoggerManager  # type: ignore[import-not-found]
 
             # Ensure stats logging is always ON.
             original_from_config = AsyncLLM.from_vllm_config
 
-            @classmethod
+            @classmethod  # type: ignore[misc]
             def patched_from_config(
                 cls_vllm: object, *args: object, **kwargs: object
             ) -> object:
@@ -121,7 +121,7 @@ class VllmEnginePatch:
                 **kwargs: object,
             ) -> object:
                 if scheduler_stats is not None:
-                    self._latest_captured_stats = scheduler_stats
+                    self._latest_captured_stats = scheduler_stats  # type: ignore[attr-defined]
                 return original_record(self, scheduler_stats, *args, **kwargs)
 
             StatLoggerManager.record = patched_record
@@ -162,7 +162,7 @@ class InferenceSchedulerServerManager(AsyncLLMServerManager):
         self.ray_request_scheduler = Scheduler()
         self.inflight_store = InflightStore()
         self.endpoints = []
-        self._lb_acquired_requests = set()
+        self._lb_acquired_requests = set()  # type: ignore[var-annotated]
 
         # Reconstruct endpoints from the new (id, handle) tuple structure
         for server_id, handle in servers:
@@ -184,7 +184,7 @@ class InferenceSchedulerServerManager(AsyncLLMServerManager):
     ) -> tuple[str, ray.actor.ActorHandle]:
         """Overrides Verl's Native Global Load Balancer with py-inference-scheduler logic."""
         if self._metrics_task is None:
-            self._metrics_task = asyncio.create_task(
+            self._metrics_task = asyncio.create_task(  # type: ignore[assignment]
                 verl_metrics_polling_loop(self.endpoints, self.inflight_store)
             )
 
@@ -202,7 +202,7 @@ class InferenceSchedulerServerManager(AsyncLLMServerManager):
                 "py-inference-scheduler returned no endpoints, falling back to verl global LB."
             )
             self._lb_acquired_requests.add(request_id)
-            return await super()._acquire_server(request_id)
+            return await super()._acquire_server(request_id)  # type: ignore[no-any-return]
 
         winning_endpoint: Endpoint = selected_endpoints[0].endpoint
         logger.info("[%s] Routed to %s", request_id[:6], winning_endpoint.name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.20.0",
     "ruff>=0.15.10",
-    "mypy>=0.970",
+    "mypy>=1.10",
+    "types-PyYAML>=6.0",
 ]
 
 [tool.setuptools]
@@ -46,10 +47,15 @@ packages = ["scheduling"]
 scheduling = ["py.typed"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
+
+# Skip following imports for third-party packages whose source uses Python 3.10+ syntax. 
+[[tool.mypy.overrides]]
+module = ["pytest.*", "ray.*"]
+follow_imports = "skip"
 
 [tool.ruff]
 target-version = "py38"

--- a/scheduling/core/config.py
+++ b/scheduling/core/config.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from scheduling.framework import (
     ProfileHandler,
@@ -40,7 +41,7 @@ class SchedulerConfig:
         )
 
     @classmethod
-    def from_dict(cls, config_dict: dict[str, object]) -> SchedulerConfig:
+    def from_dict(cls, config_dict: dict[str, Any]) -> SchedulerConfig:
         """
         Parse a nested dictionary into a SchedulerConfig.
 

--- a/scheduling/core/scheduler.py
+++ b/scheduling/core/scheduler.py
@@ -25,6 +25,7 @@ from scheduling.framework import (
     CycleState,
     Endpoint,
     LLMRequest,
+    ProfileHandler,
     ProfileRunResult,
     SchedulerProfile,
     SchedulingResult,
@@ -33,6 +34,11 @@ from scheduling.framework import (
 
 
 class Scheduler:
+    config_path: str | None
+    last_mtime: float
+    profile_handler: ProfileHandler
+    profiles: dict[str, SchedulerProfile]
+
     def __init__(self, config_path: str | None = None) -> None:
         if config_path:
             self.config_path = config_path
@@ -45,14 +51,14 @@ class Scheduler:
                     "path is passed."
                 )
 
-        self.last_mtime = 0
+        self.last_mtime = 0.0
         self._maybe_reload_config()
 
     @classmethod
     def new_with_config(cls, config: SchedulerConfig) -> Scheduler:
         instance = object.__new__(cls)
         instance.config_path = None
-        instance.last_mtime = 0
+        instance.last_mtime = 0.0
         instance.profile_handler = config.profile_handler
         instance.profiles = config.profiles
         return instance
@@ -113,14 +119,14 @@ class Scheduler:
         )
         selected_eps = (
             result.profile_results[primary].endpoint_list[:1]
-            if primary in result.profile_results
+            if primary is not None and primary in result.profile_results
             else []
         )
         print(f"Selected endpoint {selected_eps}")
-        if selected_eps:
+        if selected_eps and primary is not None:
             for w in self.profiles[primary].scorers:
                 if hasattr(w.scorer, "pre_request"):
-                    w.scorer.pre_request(cycle_state, request, selected_eps[0].endpoint)
+                    w.scorer.pre_request(cycle_state, request, selected_eps[0].endpoint)  # type: ignore[attr-defined]
         return result
 
     def run(
@@ -129,10 +135,14 @@ class Scheduler:
         self._maybe_reload_config()
         scheduler_output = self.schedule(request, candidates)
         profile_name = scheduler_output.primary_profile_name
-        profile_results = scheduler_output.profile_results.get(profile_name)
+        profile_results = (
+            scheduler_output.profile_results.get(profile_name)
+            if profile_name is not None
+            else None
+        )
 
         print(f"Profile {profile_name} results: {profile_results}")
-        selected_endpoint = profile_results.endpoint_list[:1]
+        selected_endpoint = profile_results.endpoint_list[:1] if profile_results else []
 
         if len(selected_endpoint) > 0:
             return selected_endpoint  # pick top 1

--- a/scheduling/framework/helpers.py
+++ b/scheduling/framework/helpers.py
@@ -14,13 +14,13 @@
 
 from __future__ import annotations
 
-from typing import Callable, Sequence
+from typing import Callable, Mapping
 
 from .types import Endpoint
 
 
 def score_by_metric(
-    endpoints: Sequence[Endpoint],
+    pods: Mapping[str, Endpoint],
     metric_extractor: Callable[[Endpoint], float],
     *,
     lower_is_better: bool = True,
@@ -29,7 +29,7 @@ def score_by_metric(
     Helper function to score endpoints relative to each other based on a numeric metric.
 
     Args:
-        endpoints: A sequence or dictionary values of Endpoint objects.
+        pods: Mapping of endpoint name to Endpoint.
         metric_extractor: A callable that takes an Endpoint and returns a float metric.
         lower_is_better: If True, lower metric values receive higher scores (close to 1.0).
                          If False, higher metric values receive higher scores.
@@ -37,7 +37,7 @@ def score_by_metric(
     Returns:
         A dictionary mapping endpoint names to a normalized score between 0.0 and 1.0.
     """
-    eps = endpoints.values() if isinstance(endpoints, dict) else endpoints
+    eps = list(pods.values())
 
     min_val = float("inf")
     max_val = float("-inf")

--- a/scheduling/plugins/handlers/generic.py
+++ b/scheduling/plugins/handlers/generic.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Mapping, Sequence
+from typing import Mapping
 
 from scheduling.framework import (
     CycleState,
@@ -41,22 +41,14 @@ class SimpleFilter(FilterPlugin):
         self,
         cycle_state: CycleState,
         request: LLMRequest,
-        endpoints: Sequence[Endpoint],
+        pods: Mapping[str, Endpoint],
     ) -> Mapping[str, Endpoint]:
-        if isinstance(endpoints, Mapping):
-            result: dict[str, Endpoint] = {}
-            for name, p in endpoints.items():
-                v = p.attributes.get(self.key)
-                if self.value is None or v == self.value:
-                    result[name] = p
-            return result
-
-        out: list[Endpoint] = []
-        for p in endpoints:
+        result: dict[str, Endpoint] = {}
+        for name, p in pods.items():
             v = p.attributes.get(self.key)
             if self.value is None or v == self.value:
-                out.append(p)
-        return {p.name: p for p in out}
+                result[name] = p
+        return result
 
 
 @register_profile_handler("single_profile")

--- a/scheduling/plugins/scorers/backpressure.py
+++ b/scheduling/plugins/scorers/backpressure.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Mapping, Sequence
+from typing import Mapping
 
 from scheduling.framework import (
     CycleState,
@@ -37,23 +37,17 @@ class QueueLengthScorer(ScorerPlugin):
         self.attribute_key = attribute_key
 
     def score(
-        self, cycle_state: CycleState, request: LLMRequest, endpoints: Sequence[Endpoint]
+        self, cycle_state: CycleState, request: LLMRequest, pods: Mapping[str, Endpoint]
     ) -> dict[str, float]:
-        if isinstance(endpoints, Mapping):
-            result: dict[str, float] = {}
-            for name, ep in endpoints.items():
-                raw = ep.attributes.get(self.attribute_key, 0)
-                try:
-                    size = int(raw)
-                except Exception:  # noqa: BLE001
-                    size = 0
-                result[name] = float(-size)
-            return result
-
-        return {
-            ep.name: float(-int(ep.attributes.get(self.attribute_key, 0)))
-            for ep in endpoints
-        }
+        result: dict[str, float] = {}
+        for name, ep in pods.items():
+            raw = ep.attributes.get(self.attribute_key, 0)
+            try:
+                size = int(raw)  # type: ignore[call-overload]
+            except Exception:  # noqa: BLE001
+                size = 0
+            result[name] = float(-size)
+        return result
 
 
 @register_scorer("least_queue")
@@ -61,11 +55,11 @@ class LeastQueueScorer(ScorerPlugin):
     """Scores endpoints based on their real-time Ray Serve actor queue length."""
 
     def score(
-        self, cycle_state: CycleState, request: LLMRequest, endpoints: Sequence[Endpoint]
+        self, cycle_state: CycleState, request: LLMRequest, pods: Mapping[str, Endpoint]
     ) -> dict[str, float]:
         return score_by_metric(
-            endpoints,
-            metric_extractor=lambda ep: float(ep.attributes.get("queue_len", 0)),
+            pods,
+            metric_extractor=lambda ep: float(ep.attributes.get("queue_len", 0)),  # type: ignore[arg-type]
             lower_is_better=True,
         )
 
@@ -75,12 +69,12 @@ class WaitingQueueScorer(ScorerPlugin):
     """Scores candidate endpoints based on the number of waiting requests inside the vLLM engine."""
 
     def score(
-        self, cycle_state: CycleState, request: LLMRequest, endpoints: Sequence[Endpoint]
+        self, cycle_state: CycleState, request: LLMRequest, pods: Mapping[str, Endpoint]
     ) -> dict[str, float]:
         return score_by_metric(
-            endpoints,
+            pods,
             metric_extractor=lambda ep: float(
-                ep.attributes.get("routing_stats", {}).get("num_waiting_reqs", 0)
+                ep.attributes.get("routing_stats", {}).get("num_waiting_reqs", 0)  # type: ignore[attr-defined]
             ),
             lower_is_better=True,
         )
@@ -91,12 +85,12 @@ class RunningQueueScorer(ScorerPlugin):
     """Scores candidate endpoints based on the number of running requests inside the vLLM engine."""
 
     def score(
-        self, cycle_state: CycleState, request: LLMRequest, endpoints: Sequence[Endpoint]
+        self, cycle_state: CycleState, request: LLMRequest, pods: Mapping[str, Endpoint]
     ) -> dict[str, float]:
         return score_by_metric(
-            endpoints,
+            pods,
             metric_extractor=lambda ep: float(
-                ep.attributes.get("routing_stats", {}).get("num_running_reqs", 0)
+                ep.attributes.get("routing_stats", {}).get("num_running_reqs", 0)  # type: ignore[attr-defined]
             ),
             lower_is_better=True,
         )
@@ -107,12 +101,12 @@ class KVCacheScorer(ScorerPlugin):
     """Scores candidate endpoints based on KV cache utilization."""
 
     def score(
-        self, cycle_state: CycleState, request: LLMRequest, endpoints: Sequence[Endpoint]
+        self, cycle_state: CycleState, request: LLMRequest, pods: Mapping[str, Endpoint]
     ) -> dict[str, float]:
         return score_by_metric(
-            endpoints,
+            pods,
             metric_extractor=lambda ep: float(
-                ep.attributes.get("routing_stats", {}).get("kv", 0.0)
+                ep.attributes.get("routing_stats", {}).get("kv", 0.0)  # type: ignore[attr-defined]
             ),
             lower_is_better=True,
         )

--- a/scheduling/plugins/scorers/generic.py
+++ b/scheduling/plugins/scorers/generic.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import threading
-from typing import Mapping, Sequence
+from typing import Mapping
 
 from scheduling.framework import (
     CycleState,
@@ -34,11 +34,9 @@ class ConstantScorer(ScorerPlugin):
         self.value = value
 
     def score(
-        self, cycle_state: CycleState, request: LLMRequest, endpoints: Sequence[Endpoint]
+        self, cycle_state: CycleState, request: LLMRequest, pods: Mapping[str, Endpoint]
     ) -> dict[str, float]:
-        if isinstance(endpoints, Mapping):
-            return {name: float(self.value) for name in endpoints}
-        return {p.name: float(self.value) for p in endpoints}
+        return {name: float(self.value) for name in pods}
 
 
 @register_scorer("round_robin")

--- a/scheduling/plugins/scorers/prefix_plugin.py
+++ b/scheduling/plugins/scorers/prefix_plugin.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections import OrderedDict
-from typing import Mapping, Sequence
+from typing import Mapping, Sequence, cast
 
 from scheduling.framework import CycleState, Endpoint, LLMRequest, register_scorer
 
@@ -30,7 +30,7 @@ class PrefixIndexer:
 
     def __init__(self, lru_capacity_per_server: int = 31250) -> None:
         self._hash_to_servers: dict[int, set[str]] = {}
-        self._server_to_hashes: dict[str, OrderedDict[int]] = {}
+        self._server_to_hashes: dict[str, OrderedDict[int, None]] = {}
         self._lru_capacity_per_server = lru_capacity_per_server
 
     def add(self, hashes: Sequence[int], server: str) -> None:
@@ -55,7 +55,9 @@ class PrefixIndexer:
         return set(self._hash_to_servers.get(h, set()))
 
     def remove_server(self, server: str) -> None:
-        hashes = self._server_to_hashes.pop(server, set())
+        hashes = self._server_to_hashes.pop(server, None)
+        if hashes is None:
+            return
         for h in hashes:
             servs = self._hash_to_servers.get(h)
             if not servs:
@@ -140,11 +142,8 @@ class PrefixCacheScorer:
         self,
         cycle_state: CycleState,
         request: LLMRequest,
-        endpoints: Sequence[Endpoint],
+        pods: Mapping[str, Endpoint],
     ) -> dict[str, float]:
-        # normalize endpoints to mapping name->Endpoint
-        eps = endpoints if isinstance(endpoints, Mapping) else {e.name: e for e in endpoints}
-
         body_bytes = _get_user_input_bytes(request.body)
         hashes = _hash_prompt_bytes(
             request.target_model,
@@ -157,13 +156,13 @@ class PrefixCacheScorer:
 
         total = len(hashes)
         if total == 0:
-            return dict.fromkeys(eps.keys(), 0.0)
+            return dict.fromkeys(pods.keys(), 0.0)
 
         scores: dict[str, float] = {}
         for h in hashes:
             servs = self.indexer.get(h)
             for name in servs:
-                if name not in eps:
+                if name not in pods:
                     continue
                 if name not in scores:
                     scores[name] = 1.0
@@ -173,9 +172,9 @@ class PrefixCacheScorer:
         # If a novel prompt has no matching prefixes, route to the least-loaded servers.
         if len(scores) == 0:
             min_count = min(
-                len(self.indexer._server_to_hashes.get(name, {})) for name in eps
+                len(self.indexer._server_to_hashes.get(name, {})) for name in pods
             )
-            for name in eps:
+            for name in pods:
                 if len(self.indexer._server_to_hashes.get(name, {})) == min_count:
                     scores[name] = 1.0
 
@@ -189,7 +188,7 @@ class PrefixCacheScorer:
     ) -> None:
         hashes = cycle_state.get("prefix_hashes")
         if hashes is not None:
-            self.add_prefixes_for_server(selected_endpoint.name, hashes)
+            self.add_prefixes_for_server(selected_endpoint.name, cast(Sequence[int], hashes))
         else:
             print("Warning: prefix_hashes not found in cycle_state in pre_request")
             body_bytes = _get_user_input_bytes(request.body)

--- a/tests/unit/plugins/scorers/test_prefix_plugin.py
+++ b/tests/unit/plugins/scorers/test_prefix_plugin.py
@@ -65,7 +65,11 @@ def test_prefix_cache_scorer_scores():
     if len(hashes) >= 2:
         scorer.add_prefixes_for_server("ep2", [hashes[1]])
 
-    endpoints = [Endpoint(name="ep1"), Endpoint(name="ep2"), Endpoint(name="ep3")]
+    endpoints = {
+        "ep1": Endpoint(name="ep1"),
+        "ep2": Endpoint(name="ep2"),
+        "ep3": Endpoint(name="ep3"),
+    }
     cs = CycleState()
     scores = scorer.score(cs, req, endpoints)
 

--- a/uv.lock
+++ b/uv.lock
@@ -3995,6 +3995,9 @@ dev = [
     { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "ruff" },
+    { name = "types-pyyaml", version = "6.0.12.20241230", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "types-pyyaml", version = "6.0.12.20250915", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "types-pyyaml", version = "6.0.12.20260408", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [package.metadata]
@@ -4005,10 +4008,11 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=0.970" },
+    { name = "mypy", specifier = ">=1.10" },
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-asyncio", specifier = ">=0.20.0" },
     { name = "ruff", specifier = ">=0.15.10" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]
@@ -5986,6 +5990,55 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20241230"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+    "python_full_version < '3.8.1'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/f9/4d566925bcf9396136c0a2e5dc7e230ff08d86fa011a69888dd184469d80/types_pyyaml-6.0.12.20241230.tar.gz", hash = "sha256:7f07622dbd34bb9c8b264fe860a17e0efcad00d50b5f27e93984909d9363498c", size = 17078, upload-time = "2024-12-30T02:44:38.168Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/c1/48474fbead512b70ccdb4f81ba5eb4a58f69d100ba19f17c92c0c4f50ae6/types_PyYAML-6.0.12.20241230-py3-none-any.whl", hash = "sha256:fa4d32565219b68e6dee5f67534c722e53c00d1cfc09c435ef04d7353e1e96e6", size = 20029, upload-time = "2024-12-30T02:44:36.162Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
two changes
1. Update all the scorer implementations to follow the ScorerPlugin protocol and use `pods: pods: Mapping[str, Endpoint]` (previously most of the scorer implementations were using `endpoints: Sequence[Endpoint]`)
2. Enable mypy (plus tests) in github actions
   * to get a green run and minimize the size of this PR I just added comments to ignore other type errors