### PR TITLE
fix: correct typo concensus -> consensus in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,6 @@ We expect everyone to be treated with respect, and ask that all who contribute i
 As this repo contains both implementations and framework(s) it can be common to include framework modification to support a novel plugin idea. While ideas are always welcome, these types of changes will oft be scruitnized more heavily as plugins are optional, but the framework impacts all users.
 
 The best way(s) to see these kinda of changes go smoothly is/are to:
-- Build maintainer concensus
+- Build maintainer consensus
 - Have data supporting the change
 - Have explored the current framework points and a well reasoned issue/proposal as to _why_ this extension point is needed and how it can be reused


### PR DESCRIPTION
## Summary
Fix typo in CONTRIBUTING.md line 11: `concensus` → `consensus`

## Testing
- `grep -n consensus CONTRIBUTING.md` ✓
- No other changes made

Closes #2