### PR TITLE
Flow Control Refactor into plugin

### DIFF
--- a/configs/scheduler_config.yaml
+++ b/configs/scheduler_config.yaml
@@ -22,15 +22,13 @@ data:
     profile_handler:
       type: single_profile
     profiles:
-      router_with_token_budget_and_drip:
-        flow_control:
-          type: kv_saturation
-          enable_drip: true
-          default_osl: 2000
-          drip_threshold_kv: 0.2
-          drip_interval_s: 2.0
+      epp_backpressure:
         scorers:
-          - type: round_robin
+          - type: waiting_queue
             weight: 1.0
+          - type: running_queue
+            weight: 1.0
+          - type: kv_cache
+            weight: 2.0
         picker:
           type: max_score

--- a/configs/scheduler_config.yaml
+++ b/configs/scheduler_config.yaml
@@ -24,8 +24,9 @@ data:
     profiles:
       router_with_token_budget_and_drip:
         flow_control:
-          use_token_budget: true
-          default_osl: 1024
+          type: kv_saturation
+          enable_drip: true
+          default_osl: 2000
           drip_threshold_kv: 0.2
           drip_interval_s: 2.0
         scorers:

--- a/docs/kv_saturation.md
+++ b/docs/kv_saturation.md
@@ -14,7 +14,7 @@ The KV Saturation system reduces this by ensuring a request is **only** admitted
 *   **Learning Phase:** During the first encounter with a prompt, the router records the actual Input Sequence Length (ISL) and Output Sequence Length (OSL).
 *   **Virtual Reservation:** For all subsequent requests with the same fingerprint, the router calculates the full memory footprint of the request (ISL + OSL). It maintains a virtual counter of tokens occupied on each replica and will park new requests in an asynchronous queue if the addition of the new request would exceed the hardware's KV token budget.
 
-### 2. The Drip Mechanism
+### 2. The Drip Mechanism - Experimental
 In batch-heavy workloads, requests often finish in "cliffs"—where utilization drops significantly because the router waits for a full completion before admitting the next batch. This creates significant GPU idle time.
 
 The **Drip** functionality acts as a controlled "pressure valve" to smooth out these utilization cliffs. This is used only when the virtual KV Cache for a replica is already exhausted. If a replica's physical KV cache usage falls below a specific threshold (decided by the user for now), the router will "drip" one extra request into that replica, even if the virtual budget is technically full. This ensures that as one batch finishes, there are still requests partially through their prefill/decode phase, raising the floor of average utilization.

--- a/docs/kv_saturation.md
+++ b/docs/kv_saturation.md
@@ -2,7 +2,7 @@
 
 The KV Saturation system is a flow control mechanism designed to maximize sampling throughput in memory-intensive sampling workloads by preventing KV cache preemptions.
 
-Currently, this feature is only available in the **Ray Serve** implementation.
+Currently, this feature is implemented as a plugin in the **Ray Serve** integration.
 
 ## Core Concepts
 
@@ -17,31 +17,30 @@ The KV Saturation system reduces this by ensuring a request is **only** admitted
 ### 2. The Drip Mechanism
 In batch-heavy workloads, requests often finish in "cliffs"—where utilization drops significantly because the router waits for a full completion before admitting the next batch. This creates significant GPU idle time.
 
-The **Drip** functionality acts as a controlled "pressure valve" to smooth out these utilization cliffs. This is used only when the virtual KV Cache for a replica is already exhausted.If a replica's physical KV cache usage falls below a specific threshold (decided by the user for now), the router will "drip" one extra request into that replica, even if the virtual budget is technically full. This ensures that as one batch finishes, there are still requests partially through their prefill/decode phase, raising the floor of average utilization.
+The **Drip** functionality acts as a controlled "pressure valve" to smooth out these utilization cliffs. This is used only when the virtual KV Cache for a replica is already exhausted. If a replica's physical KV cache usage falls below a specific threshold (decided by the user for now), the router will "drip" one extra request into that replica, even if the virtual budget is technically full. This ensures that as one batch finishes, there are still requests partially through their prefill/decode phase, raising the floor of average utilization.
 
 ## Configuration
 
-The system is configured via the `flow_control` block in `scheduler_config.yaml`.
+The system is configured via the `flow_control` block in `scheduler_config.yaml`. Flow control is enabled at the profile level by specifying the plugin type.
 
 ### Example Configuration
 
 ```yaml
 profiles:
-  default_profile:
+  default:
     flow_control:
-      use_token_budget: true      # Toggle to use KV saturation flow control
-      default_osl: 1024           # OSL estimate for the very first contact (profiling)
-      drip_threshold_kv: 0.2      # Drip if physical KV usage < 20%
-      drip_interval_s: 2.0        # Limit drips to one every 2 seconds per replica
+      type: kv_saturation      # Specifies the flow control plugin
+      enable_drip: true        # Enable the drip mechanism
+      default_osl: 1024        # OSL estimate for the very first contact (profiling)
+      drip_threshold_kv: 0.2   # Drip if physical KV usage < 20%
+      drip_interval_s: 2.0     # Limit drips to one every 2 seconds per replica
 ```
 
 #### Strict Budgeting Mode (No Drip)
-To enforce a mathematically strict budget where preemptions are theoretically impossible, you should disable the drip mechanism by setting the threshold to zero and the interval to a maximum value:
-
+To enforce a mathematically strict budget where preemptions are theoretically impossible, you can disable the drip mechanism by setting `enable_drip: false`:
 ```yaml
     flow_control:
-      use_token_budget: true
-      drip_threshold_kv: 0.0
-      drip_interval_s: 99999999.0
+      type: kv_saturation
+      enable_drip: false
+      default_osl: 1024
 ```
-

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -16,10 +16,8 @@ from __future__ import annotations
 
 import asyncio
 import random
-import struct
-import time
 import uuid
-from typing import Any, Callable
+from typing import Callable, Sequence
 
 from ray import serve
 from ray.actor import ActorHandle
@@ -46,11 +44,111 @@ from datalayer.rayserve.engine import MetricsAwareLLMServer
 from scheduling.core.scheduler import Scheduler
 from scheduling.framework import (
     Endpoint,
+    FlowControlPlugin,
     LLMRequest,
 )
 
-NAMESPACE_FOR_UUID = uuid.uuid5(uuid.NAMESPACE_DNS, "llmd.inference.scheduler")
-_DEFAULT_USE_TOKEN_BUDGET = False
+
+class FlowControlManager:
+    def __init__(self, router: IGWRouter) -> None:
+        self.router = router
+        self.scheduler = router.scheduler
+        self.admission_queue: list[asyncio.Future] = []
+        self.loop: asyncio.AbstractEventLoop | None = None
+
+    def _get_plugins(self) -> list[FlowControlPlugin]:
+        return self.scheduler.get_flow_control_plugins()
+
+    async def admit(
+        self,
+        request: LLMRequest,
+        endpoints: Sequence[Endpoint],
+        candidate_replicas: list[RunningReplica],
+        pending_request: PendingRequest,
+    ) -> tuple[list[RunningReplica], Sequence[Endpoint]]:
+        if self.loop is None:
+            self.loop = asyncio.get_event_loop()
+
+        plugins = self._get_plugins()
+        if not plugins:
+            return candidate_replicas, endpoints
+
+        while True:
+            allowed_eps: Sequence[Endpoint] = endpoints
+            for plugin in plugins:
+                allowed_eps = plugin.get_allowed_candidates(request, allowed_eps)
+
+            if allowed_eps:
+                allowed_names = {e.name for e in allowed_eps}
+                allowed_replicas = [
+                    r for r in candidate_replicas if str(r.replica_id) in allowed_names
+                ]
+                return allowed_replicas, allowed_eps
+
+            fut = self.loop.create_future()
+            self.admission_queue.append(fut)
+            await fut
+
+            # Refetch stats because we blocked and conditions changed
+            endpoints = await self.router.build_endpoints(candidate_replicas, pending_request)
+
+    def commit(self, request: LLMRequest, selected: Endpoint) -> None:
+        for plugin in self._get_plugins():
+            plugin.reserve(request, selected)
+
+    def release(self, request: LLMRequest, replica_id: str) -> None:
+        plugins = self._get_plugins()
+        for plugin in plugins:
+            plugin.release(request, replica_id)
+
+        if plugins and self.admission_queue:
+            waiter = self.admission_queue.pop(0)
+            if not waiter.done():
+                waiter.set_result(True)
+
+    def attach_learning_callback(
+        self,
+        request: LLMRequest,
+        result: ReplicaResult,
+        is_streaming: bool,  # noqa: FBT001
+    ) -> None:
+        plugins = self._get_plugins()
+        if not plugins:
+            return
+
+        # we only have one flow control plugin right now
+        plugin = plugins[0]
+        rollout_request_id, _ = plugin._get_rollout_request_id(request.body)
+
+        if not is_streaming:
+            original_get_async = result.get_async
+
+            async def patched_get_async():
+                response = await original_get_async()
+                if response and hasattr(response, "usage") and response.usage:
+                    for plugin in plugins:
+                        plugin.update_learned_stats(
+                            rollout_request_id,
+                            response.usage.prompt_tokens,
+                            response.usage.completion_tokens,
+                        )
+                return response
+
+            result.get_async = patched_get_async
+        else:
+            original_anext = result.__anext__
+
+            async def patched_anext():
+                chunk = await original_anext()
+                if chunk and hasattr(chunk, "usage") and chunk.usage:
+                    for plugin in plugins:
+                        plugin.update_learned_stats(
+                            rollout_request_id,
+                            chunk.usage.prompt_tokens,
+                            chunk.usage.completion_tokens,
+                        )
+                return chunk
+            result.__anext__ = patched_anext
 
 
 class IGWRouter(RequestRouter):
@@ -79,23 +177,8 @@ class IGWRouter(RequestRouter):
         )
         self.scheduler = Scheduler()
         self.deployment_name = deployment_id.name
-
-        # rollout_request_id -> {isl, max_osl}
-        self._rollout_request_stats: dict[str, dict[str, int]] = {}
-
-        # replica_id -> token_usage_at_replica
-        self._replica_token_usage: dict[ReplicaID, int] = {}
-
-        # request_id -> (replica_id, tokens)
-        self._request_at_replica: dict[str, tuple[ReplicaID, int]] = {}
-
-        # FIFO queue for blocked requests
-        self._admission_queue: list[asyncio.Future] = []
-
-        self._last_drip_at = 0.0
+        self.fc_manager = FlowControlManager(self)
         self._loop: asyncio.AbstractEventLoop | None = None
-        self._budgeted_requests: set[str] = set()
-        self._replica_kv_cache_size: dict[ReplicaID, int] = {}
 
     async def _get_routing_stats(
         self, replicas: list[RunningReplica], pending_request: PendingRequest
@@ -107,6 +190,40 @@ class IGWRouter(RequestRouter):
         ]
         results = await asyncio.gather(*futures, return_exceptions=True)
         return [res if not isinstance(res, BaseException) else {} for res in results]
+
+    async def build_endpoints(
+        self, replicas: list[RunningReplica], pending_request: PendingRequest
+    ) -> list[Endpoint]:
+        metrics_results = await self._get_routing_stats(replicas, pending_request)
+
+        endpoints = []
+        for replica, routing_stats in zip(replicas, metrics_results):
+            queue_len = 0
+            if self.replica_queue_len_cache:
+                cached_val = self.replica_queue_len_cache.get(replica.replica_id)
+                if cached_val is not None:
+                    queue_len = cached_val
+
+            kv_cache_size = routing_stats.get("kv_cache_size", -1)
+
+            endpoints.append(
+                Endpoint(
+                    name=str(replica.replica_id),
+                    attributes={
+                        "queue_len": queue_len,
+                        "routing_stats": routing_stats,
+                        "kv_cache_size": kv_cache_size,
+                    },
+                )
+            )
+        return endpoints
+
+    def _fallback_random_choice(
+        self, candidate_replicas: list[RunningReplica]
+    ) -> list[list[RunningReplica]]:
+        """Helper to pick a random replica as fallback."""
+        index = random.randint(0, len(candidate_replicas) - 1)  # noqa: S311
+        return [[candidate_replicas[index]]]
 
     def _parse_to_llm_request(self, pending_request: PendingRequest) -> LLMRequest:
         """Converts Ray request to LLMRequest."""
@@ -128,121 +245,7 @@ class IGWRouter(RequestRouter):
 
         return LLMRequest(request_id=req_id, body=body, target_model=target_model)
 
-    def _get_rollout_request_id(self, body: Any) -> tuple[str, int]:  # noqa: ANN401
-        """Generates a rollout request ID and approximate character length from the request body.
-
-        We don't require character length to be accurate, it is used as a
-        fail-safe and for edge cases.
-        """
-        if not body:
-            return "", 0
-
-        try:
-            # Case 1: Pre-tokenized prompt ids (List[int])
-            if isinstance(body, list) and len(body) > 0 and isinstance(body[0], int):
-                prompt_bytes = struct.pack(f"{len(body)}i", *body)
-                return uuid.uuid5(NAMESPACE_FOR_UUID, prompt_bytes.hex()).hex, len(body) * 4
-
-            # Case 2: Raw string or bytes prompt
-            if isinstance(body, (str, bytes)):
-                prompt_str = body if isinstance(body, str) else body.hex()
-                return uuid.uuid5(NAMESPACE_FOR_UUID, prompt_str).hex, len(body)
-
-            # Case 3: List of messages (Dicts/Pydantic models)
-            if isinstance(body, list):
-                extracted_text = ""
-                for m in body:
-                    if isinstance(m, dict):
-                        extracted_text += str(m.get("content", ""))
-                    else:
-                        extracted_text += str(getattr(m, "content", ""))
-                char_len = len(extracted_text)
-                return uuid.uuid5(NAMESPACE_FOR_UUID, extracted_text).hex, char_len
-
-        except Exception as e:  # noqa: BLE001
-            print(f"[ROUTER ERROR] Failed to parse request ID securely: {e}")
-
-        return "", 0
-
-    async def _wait_for_space(self) -> None:
-        """Wait until at least one replica has space freed up."""
-        if self._loop is None:
-            raise RuntimeError("Event loop is not initialized")
-        fut = self._loop.create_future()
-        self._admission_queue.append(fut)
-        await fut
-
-    def _get_available_replicas(
-        self,
-        candidate_replicas: list[RunningReplica],
-        tokens_required: int,
-    ) -> list[RunningReplica]:
-        """Return subset of replicas that can fit the required tokens."""
-        res = []
-        for r in candidate_replicas:
-            budget = self._replica_kv_cache_size.get(r.replica_id)
-            if (
-                budget is not None
-                and budget > 0
-                and (self._replica_token_usage.get(r.replica_id, 0) + tokens_required <= budget)
-            ):
-                res.append(r)
-        return res
-
-    def _token_budget_needed(self, request_id: str | None, fc: dict) -> bool:
-        """Decide if this request requires token budgeting."""
-        use_token_budget = fc.get("use_token_budget", _DEFAULT_USE_TOKEN_BUDGET)
-        return bool(use_token_budget and request_id and request_id not in self._budgeted_requests)
-
-    def _estimate_tokens_required(self, rollout_id: str, char_len: int, fc: dict) -> int:
-        """Estimate the tokens required for this request."""
-        stats = self._rollout_request_stats.get(rollout_id)
-        if stats:
-            return stats["isl"] + stats["osl"]
-
-        # Fallback for first contact with prompt
-        default_osl: int = fc.get("default_osl", 1024)
-        return (char_len // 4) + default_osl
-
-    def _maybe_drip(
-        self, replicas: list[RunningReplica], stats: list[dict], fc: dict
-    ) -> RunningReplica | None:
-        """Check if any replica qualifies for drip admission."""
-        now = time.time()
-        drip_interval_s = fc.get("drip_interval_s", 2.0)
-        if (now - self._last_drip_at) < drip_interval_s:
-            return None
-
-        drip_threshold_kv = fc.get("drip_threshold_kv", 0.1)
-        for i, r in enumerate(replicas):
-            physical_kv = stats[i].get("kv", 1.0)
-            if physical_kv < drip_threshold_kv:
-                self._last_drip_at = now
-                print(f"[BUDGET] Drip Admission to {r.replica_id} (Physical KV: {physical_kv:.2f})")
-                return r
-        return None
-
-    async def _wait_for_admission(
-        self,
-        replicas: list[RunningReplica],
-        tokens: int,
-        pending_request: PendingRequest,
-        fc: dict,
-    ) -> list[RunningReplica]:
-        """Wait loop until replicas are available or a drip admission occurs."""
-        while True:
-            available = self._get_available_replicas(replicas, tokens)
-            if available:
-                return available
-
-            new_stats = await self._get_routing_stats(replicas, pending_request)
-            drip_replica = self._maybe_drip(replicas, new_stats, fc)
-            if drip_replica:
-                return [drip_replica]
-
-            await self._wait_for_space()
-
-    async def choose_replicas(  # noqa: PLR0912, PLR0914, C901
+    async def choose_replicas(
         self,
         candidate_replicas: list[RunningReplica],
         pending_request: PendingRequest | None = None,
@@ -254,101 +257,61 @@ class IGWRouter(RequestRouter):
             return []
 
         llm_req = self._parse_to_llm_request(pending_request)
-        rollout_request_id, char_len = self._get_rollout_request_id(llm_req.body)
-        request_id = llm_req.request_id
 
         # for health check empty requests
-        if not pending_request or not pending_request.args or char_len == 0:
-            index = random.randint(0, len(candidate_replicas) - 1)  # noqa: S311
-            return [[candidate_replicas[index]]]
+        if not pending_request or not pending_request.args or not llm_req.body:
+            return self._fallback_random_choice(candidate_replicas)
 
         try:
-            metrics_results = await self._get_routing_stats(candidate_replicas, pending_request)
+            endpoints: Sequence[Endpoint] = await self.build_endpoints(
+                candidate_replicas, pending_request
+            )
+        except Exception as e:  # noqa: BLE001
+            print(
+                f"[ROUTER ERROR] Failed to build endpoints: {e!r}. Falling back to random choice."
+            )
+            return self._fallback_random_choice(candidate_replicas)
 
-            candidates = []
-            for replica, routing_stats in zip(candidate_replicas, metrics_results):
-                queue_len = 0
-                if self.replica_queue_len_cache:
-                    cached_val = self.replica_queue_len_cache.get(replica.replica_id)
-                    if cached_val is not None:
-                        queue_len = cached_val
-
-                # Discover and cache KV Cache size if not already known
-                if replica.replica_id not in self._replica_kv_cache_size:
-                    kv_cache_size = routing_stats.get("kv_cache_size", -1)
-                    if kv_cache_size > 0:
-                        self._replica_kv_cache_size[replica.replica_id] = kv_cache_size
-                        print(
-                            f"[BUDGET] Discovered KV Cache size for replica {replica.replica_id}: "
-                            f"{kv_cache_size} tokens"
-                        )
-
-                if isinstance(routing_stats, Exception):
-                    print(
-                        f"Failed to fetch metrics via RPC for {replica.replica_id}: {routing_stats}"
-                    )
-                    routing_stats = {}  # noqa: PLW2901
-
-                candidates.append(
-                    Endpoint(
-                        name=str(replica.replica_id),
-                        attributes={
-                            "queue_len": queue_len,
-                            "routing_stats": routing_stats,
-                        },
-                    )
+        try:
+            if self.scheduler.has_flow_control():
+                candidate_replicas, endpoints = await self.fc_manager.admit(
+                    llm_req, endpoints, candidate_replicas, pending_request
                 )
+        except Exception as e:  # noqa: BLE001
+            print(
+                f"[ROUTER ERROR] Flow control admission failed: {e!r}. "
+                f"Falling back to random choice."
+            )
+            return self._fallback_random_choice(candidate_replicas)
 
-            fc = self.scheduler.get_flow_control_config()
-            tokens_required = 0
-            is_budgeted = False
-
-            if self._token_budget_needed(request_id, fc):
-                tokens_required = self._estimate_tokens_required(rollout_request_id, char_len, fc)
-                candidate_replicas = await self._wait_for_admission(
-                    candidate_replicas, tokens_required, pending_request, fc
-                )
-                is_budgeted = True
-
-                # Sync scheduler candidates with available replicas
-                available_replica_ids = {str(r.replica_id) for r in candidate_replicas}
-                candidates = [c for c in candidates if c.name in available_replica_ids]
-            selected_endpoints = self.scheduler.run(llm_req, candidates)
-
+        try:
+            selected_endpoints = self.scheduler.run(llm_req, endpoints)
             index = -1
             for i, replica in enumerate(candidate_replicas):
                 if (
                     len(selected_endpoints) > 0
-                    and str(replica.replica_id) == selected_endpoints[0].endpoint.name
+                    and str(replica.replica_id)
+                    == selected_endpoints[0].endpoint.name
                 ):
                     index = i
                     break
             if index == -1:
                 index = random.randint(0, len(candidate_replicas) - 1)  # noqa: S311
-
             target_replica = candidate_replicas[index]
-
-            # Commit the reservation for the selected replica
-            if is_budgeted:
-                self._replica_token_usage[target_replica.replica_id] = (
-                    self._replica_token_usage.get(target_replica.replica_id, 0) + tokens_required
-                )
-                self._request_at_replica[request_id] = (
-                    target_replica.replica_id,
-                    tokens_required,
-                )
-                self._budgeted_requests.add(request_id)
-                print(
-                    f"[BUDGET] Admission committed for req={request_id} "
-                    f"to replica={target_replica.replica_id} "
-                    f"(Usage: {self._replica_token_usage[target_replica.replica_id]})"
-                )
-
-            return [[target_replica]]  # noqa: TRY300
         except Exception as e:  # noqa: BLE001
-            print(f"Error of: {e!r} during scheduling: {e}, defaulting to random choice")
-            index = random.randint(0, len(candidate_replicas) - 1)  # noqa: S311
-            return [[candidate_replicas[index]]]
+            print(
+                f"[ROUTER ERROR] Scheduling or mapping failed: {e!r}. "
+                f"Falling back to random choice."
+            )
+            return self._fallback_random_choice(candidate_replicas)
+
+        try:
+            if self.scheduler.has_flow_control() and selected_endpoints:
+                self.fc_manager.commit(llm_req, selected_endpoints[0].endpoint)
+        except Exception as e:  # noqa: BLE001
+            print(f"[ROUTER WARNING] Failed to commit reservation: {e!r}")
+
+        return [[target_replica]]
 
     def on_request_routed(
         self,
@@ -357,59 +320,11 @@ class IGWRouter(RequestRouter):
         result: ReplicaResult,
     ) -> None:
         llm_req = self._parse_to_llm_request(pending_request)
-        request_id = llm_req.request_id
-        rollout_request_id, char_len = self._get_rollout_request_id(llm_req.body)
-        routed_at = time.time()
         is_streaming = pending_request.metadata.is_streaming
 
-        def _on_done(_):
-            elapsed = time.time() - routed_at
-            if request_id in self._request_at_replica:
-                replica_id_to_reclaim, tokens = self._request_at_replica.pop(request_id)
-                self._replica_token_usage[replica_id_to_reclaim] = max(
-                    0, self._replica_token_usage.get(replica_id_to_reclaim, 0) - tokens
-                )
-                self._budgeted_requests.discard(request_id)
-                print(
-                    f"[BUDGET] Released req={request_id} from replica={replica_id_to_reclaim}. "
-                    f"Elapsed={elapsed:.3f}s. "
-                    f"Usage={self._replica_token_usage[replica_id_to_reclaim]}"
-                )
-
-                if self._admission_queue:
-                    waiter = self._admission_queue.pop(0)
-                    if not waiter.done():
-                        waiter.set_result(True)
-
-        result.add_done_callback(_on_done)
-
-        if char_len > 0:
-            if not is_streaming:
-                original_get_async = result.get_async
-
-                async def patched_get_async():
-                    response = await original_get_async()
-                    if response and hasattr(response, "usage") and response.usage:
-                        self._rollout_request_stats[rollout_request_id] = {
-                            "isl": response.usage.prompt_tokens,
-                            "osl": response.usage.completion_tokens,
-                        }
-                    return response
-
-                result.get_async = patched_get_async
-            else:
-                original_anext = result.__anext__
-
-                async def patched_anext():
-                    chunk = await original_anext()
-                    if chunk and hasattr(chunk, "usage") and chunk.usage:
-                        self._rollout_request_stats[rollout_request_id] = {
-                            "isl": chunk.usage.prompt_tokens,
-                            "osl": chunk.usage.completion_tokens,
-                        }
-                    return chunk
-
-                result.__anext__ = patched_anext
+        if self.scheduler.has_flow_control():
+            result.add_done_callback(lambda _: self.fc_manager.release(llm_req, str(replica_id)))
+            self.fc_manager.attach_learning_callback(llm_req, result, is_streaming)
 
 
 # Hooking into Ray Serve's Request Router

--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -118,7 +118,7 @@ class FlowControlManager:
 
         # we only have one flow control plugin right now
         plugin = plugins[0]
-        rollout_request_id, _ = plugin._get_rollout_request_id(request.body)
+        rollout_request_id, _ = plugin._get_rollout_request_id(request.body)  # type: ignore[attr-defined]
 
         if not is_streaming:
             original_get_async = result.get_async
@@ -127,7 +127,7 @@ class FlowControlManager:
                 response = await original_get_async()
                 if response and hasattr(response, "usage") and response.usage:
                     for plugin in plugins:
-                        plugin.update_learned_stats(
+                        plugin.update_learned_stats(  # type: ignore[attr-defined]
                             rollout_request_id,
                             response.usage.prompt_tokens,
                             response.usage.completion_tokens,
@@ -142,7 +142,7 @@ class FlowControlManager:
                 chunk = await original_anext()
                 if chunk and hasattr(chunk, "usage") and chunk.usage:
                     for plugin in plugins:
-                        plugin.update_learned_stats(
+                        plugin.update_learned_stats(  # type: ignore[attr-defined]
                             rollout_request_id,
                             chunk.usage.prompt_tokens,
                             chunk.usage.completion_tokens,

--- a/scheduling/core/config.py
+++ b/scheduling/core/config.py
@@ -22,6 +22,7 @@ from scheduling.framework import (
     SchedulerProfile,
     WeightedScorer,
     build_filter,
+    build_flow_control,
     build_picker,
     build_profile_handler,
     build_scorer,
@@ -41,7 +42,7 @@ class SchedulerConfig:
         )
 
     @classmethod
-    def from_dict(cls, config_dict: dict[str, Any]) -> SchedulerConfig:
+    def from_dict(cls, config_dict: dict[str, Any]) -> SchedulerConfig:  # noqa: PLR0914
         """
         Parse a nested dictionary into a SchedulerConfig.
 
@@ -68,7 +69,12 @@ class SchedulerConfig:
         parsed_profiles: dict[str, SchedulerProfile] = {}
         for profile_name, prof_data in profiles_dict.items():
             profile = SchedulerProfile(name=profile_name)
-            profile.flow_control = prof_data.get("flow_control", {})
+
+            fc_config = prof_data.get("flow_control")
+            if fc_config:
+                cfg = dict(fc_config)
+                fc_type = cfg.pop("type")
+                profile.flow_controls = [build_flow_control(fc_type, **cfg)]
 
             for filter_config in prof_data.get("filters", []):
                 cfg = dict(filter_config)

--- a/scheduling/core/scheduler.py
+++ b/scheduling/core/scheduler.py
@@ -53,7 +53,6 @@ class Scheduler:
                 )
 
         self.last_mtime = 0.0
-        self._maybe_reload_config()
 
     @classmethod
     def new_with_config(cls, config: SchedulerConfig) -> Scheduler:
@@ -95,6 +94,7 @@ class Scheduler:
     def schedule(
         self, request: LLMRequest, candidates: Sequence[Endpoint]
     ) -> SchedulingResult:
+        self._maybe_reload_config()
         if not candidates:
             raise ValueError("no scheduling candidates provided")
 

--- a/scheduling/core/scheduler.py
+++ b/scheduling/core/scheduler.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import os
 import pathlib
-from typing import Any, Sequence
+from typing import Sequence
 
 import yaml
 
@@ -24,6 +24,7 @@ from scheduling.core.config import SchedulerConfig
 from scheduling.framework import (
     CycleState,
     Endpoint,
+    FlowControlPlugin,
     LLMRequest,
     ProfileHandler,
     ProfileRunResult,
@@ -63,13 +64,18 @@ class Scheduler:
         instance.profiles = config.profiles
         return instance
 
-    def get_flow_control_config(self) -> dict[str, Any]:
-        """Returns the flow_control configuration from the primary profile, or an empty dict."""
-        self._maybe_reload_config()
+    def has_flow_control(self) -> bool:
+        """Returns True if any profile has any flow control plugins."""
+        return bool(self.get_flow_control_plugins())
+
+    def get_flow_control_plugins(self) -> list[FlowControlPlugin]:
+        """Returns all flow control plugins from all profiles."""
+        all_plugins = []
         if hasattr(self, "profiles") and self.profiles:
-            primary_profile = next(iter(self.profiles.values()))
-            return getattr(primary_profile, "flow_control", {})
-        return {}
+            for profile in self.profiles.values():
+                if profile.flow_controls:
+                    all_plugins.extend(profile.flow_controls)
+        return all_plugins
 
     def _maybe_reload_config(self) -> None:
         if self.config_path is None:

--- a/scheduling/framework/__init__.py
+++ b/scheduling/framework/__init__.py
@@ -17,6 +17,9 @@ from .interface import (
     FilterPlugin as FilterPlugin,
 )
 from .interface import (
+    FlowControlPlugin as FlowControlPlugin,
+)
+from .interface import (
     PickerPlugin as PickerPlugin,
 )
 from .interface import (
@@ -35,6 +38,9 @@ from .registry import (
     _FILTERS as _FILTERS,
 )
 from .registry import (
+    _FLOW_CONTROLS as _FLOW_CONTROLS,
+)
+from .registry import (
     _PICKERS as _PICKERS,
 )
 from .registry import (
@@ -45,6 +51,9 @@ from .registry import (
 )
 from .registry import (
     build_filter as build_filter,
+)
+from .registry import (
+    build_flow_control as build_flow_control,
 )
 from .registry import (
     build_picker as build_picker,
@@ -60,6 +69,9 @@ from .registry import (
 )
 from .registry import (
     register_filter as register_filter,
+)
+from .registry import (
+    register_flow_control as register_flow_control,
 )
 from .registry import (
     register_picker as register_picker,

--- a/scheduling/framework/interface.py
+++ b/scheduling/framework/interface.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Protocol, Sequence
+from typing import Mapping, Protocol, Sequence
 
 from .types import CycleState, Endpoint, LLMRequest, ProfileRunResult, ScoredEndpoint
 
@@ -49,10 +49,6 @@ class FlowControlPlugin(Protocol):
     def reserve(self, request: LLMRequest, selected: Endpoint) -> None: ...
 
     def release(self, request: LLMRequest, endpoint_name: str) -> None: ...
-
-    def update_learned_stats(self, rollout_request_id: str, isl: int, osl: int) -> None: ...
-
-    def _get_rollout_request_id(self, body: Any) -> tuple[str, int]: ...  # noqa: ANN401
 
 
 class ProfileHandler(Protocol):

--- a/scheduling/framework/interface.py
+++ b/scheduling/framework/interface.py
@@ -41,6 +41,20 @@ class PickerPlugin(Protocol):
     ) -> ScoredEndpoint | None: ...
 
 
+class FlowControlPlugin(Protocol):
+    def get_allowed_candidates(
+        self, request: LLMRequest, candidates: Sequence[Endpoint]
+    ) -> Sequence[Endpoint]: ...
+
+    def reserve(self, request: LLMRequest, selected: Endpoint) -> None: ...
+
+    def release(self, request: LLMRequest, endpoint_name: str) -> None: ...
+
+    def update_learned_stats(self, rollout_request_id: str, isl: int, osl: int) -> None: ...
+
+    def _get_rollout_request_id(self, body: Any) -> tuple[str, int]: ...  # noqa: ANN401
+
+
 class ProfileHandler(Protocol):
     def pick(
         self,
@@ -70,7 +84,7 @@ class SchedulerProfile:
     filters: list[FilterPlugin] = field(default_factory=list)
     scorers: list[WeightedScorer] = field(default_factory=list)
     picker: PickerPlugin | None = None
-    flow_control: dict[str, Any] = field(default_factory=dict)
+    flow_controls: list[FlowControlPlugin] = field(default_factory=list)
 
     def with_filters(self, *fs: FilterPlugin) -> SchedulerProfile:
         self.filters.extend(fs)

--- a/scheduling/framework/registry.py
+++ b/scheduling/framework/registry.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Callable, TypeVar
 
-from .interface import FilterPlugin, PickerPlugin, ProfileHandler, ScorerPlugin
+from .interface import FilterPlugin, FlowControlPlugin, PickerPlugin, ProfileHandler, ScorerPlugin
 
 T = TypeVar("T")
 
@@ -25,6 +25,7 @@ _SCORERS: dict[str, type[ScorerPlugin]] = {}
 _PICKERS: dict[str, type[PickerPlugin]] = {}
 _FILTERS: dict[str, type[FilterPlugin]] = {}
 _PROFILE_HANDLERS: dict[str, type[ProfileHandler]] = {}
+_FLOW_CONTROLS: dict[str, type[FlowControlPlugin]] = {}
 
 
 def register_scorer(name: str) -> Callable[[type[ScorerPlugin]], type[ScorerPlugin]]:
@@ -69,6 +70,18 @@ def register_profile_handler(
     return wrapper
 
 
+def register_flow_control(
+    name: str,
+) -> Callable[[type[FlowControlPlugin]], type[FlowControlPlugin]]:
+    """Decorator to register a custom FlowControl class under a specific string name."""
+
+    def wrapper(cls: type[FlowControlPlugin]) -> type[FlowControlPlugin]:
+        _FLOW_CONTROLS[name] = cls
+        return cls
+
+    return wrapper
+
+
 def build_plugin(registry: dict[str, type[T]], type_name: str, **kwargs: object) -> T:
     """Helper method to instantiate a class from a specific registry category by its string name."""
     cls = registry.get(type_name)
@@ -99,3 +112,8 @@ def build_filter(type_name: str, **kwargs: object) -> FilterPlugin:
 def build_profile_handler(type_name: str, **kwargs: object) -> ProfileHandler:
     """Instantiate a registered ProfileHandler class based on its string identifier and config."""
     return build_plugin(_PROFILE_HANDLERS, type_name, **kwargs)
+
+
+def build_flow_control(type_name: str, **kwargs: object) -> FlowControlPlugin:
+    """Instantiate a registered FlowControl class based on its string identifier and config."""
+    return build_plugin(_FLOW_CONTROLS, type_name, **kwargs)

--- a/scheduling/plugins/__init__.py
+++ b/scheduling/plugins/__init__.py
@@ -12,33 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Import sub-modules to trigger registration side-effects
-from .handlers import generic as generic_handlers  # noqa: F401
-from .handlers.generic import SimpleFilter as SimpleFilter
-from .handlers.generic import SingleProfileHandler as SingleProfileHandler
-from .pickers import generic as generic_pickers  # noqa: F401
-from .pickers.generic import MaxScorePicker as MaxScorePicker
-from .pickers.generic import RandomPicker as RandomPicker
-from .scorers import backpressure as backpressure
-from .scorers import generic as generic
-from .scorers import prefix_plugin as prefix_plugin
-from .scorers.backpressure import (
-    KVCacheScorer as KVCacheScorer,
-)
-from .scorers.backpressure import (
-    LeastQueueScorer as LeastQueueScorer,
-)
-from .scorers.backpressure import (
-    QueueLengthScorer as QueueLengthScorer,
-)
-from .scorers.backpressure import (
-    RunningQueueScorer as RunningQueueScorer,
-)
-from .scorers.backpressure import (
-    WaitingQueueScorer as WaitingQueueScorer,
-)
-from .scorers.generic import ConstantScorer as ConstantScorer
-from .scorers.generic import RoundRobinScorer as RoundRobinScorer
+"""Plugins for the scheduler."""
 
-# Re-export key plugins if needed, but registry handles dynamic lookup
-from .scorers.prefix_plugin import PrefixCacheScorer as PrefixCacheScorer
+# Re-export plugins from sub-packages to maintain backward compatibility
+from .flow_control import KVSaturationPlugin as KVSaturationPlugin
+from .handlers import SimpleFilter as SimpleFilter
+from .handlers import SingleProfileHandler as SingleProfileHandler
+from .pickers import MaxScorePicker as MaxScorePicker
+from .pickers import RandomPicker as RandomPicker
+from .scorers import ConstantScorer as ConstantScorer
+from .scorers import KVCacheScorer as KVCacheScorer
+from .scorers import LeastQueueScorer as LeastQueueScorer
+from .scorers import PrefixCacheScorer as PrefixCacheScorer
+from .scorers import QueueLengthScorer as QueueLengthScorer
+from .scorers import RoundRobinScorer as RoundRobinScorer
+from .scorers import RunningQueueScorer as RunningQueueScorer
+from .scorers import WaitingQueueScorer as WaitingQueueScorer

--- a/scheduling/plugins/flow_control/__init__.py
+++ b/scheduling/plugins/flow_control/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Profile handler plugins."""
+"""Flow control plugins."""
 
-from . import generic as generic_handlers  # noqa: F401
-from .generic import SimpleFilter as SimpleFilter
-from .generic import SingleProfileHandler as SingleProfileHandler
+from .kv_saturation import KVSaturationPlugin as KVSaturationPlugin

--- a/scheduling/plugins/flow_control/kv_saturation.py
+++ b/scheduling/plugins/flow_control/kv_saturation.py
@@ -1,0 +1,176 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import time
+from typing import Any, Sequence
+
+from scheduling.framework import (
+    Endpoint,
+    FlowControlPlugin,
+    LLMRequest,
+    register_flow_control,
+)
+
+
+@register_flow_control("kv_saturation")
+class KVSaturationPlugin(FlowControlPlugin):
+    def __init__(self, **config: Any) -> None:  # noqa: ANN401
+        self.config = config
+        # rollout_request_id -> {isl, max_osl}
+        self._rollout_request_stats: dict[str, dict[str, int]] = {}
+        # replica_id -> token_usage_at_replica
+        self._replica_token_usage: dict[str, int] = {}
+        # request_id -> (replica_id, tokens)
+        self._request_at_replica: dict[str, tuple[str, int]] = {}
+        # request_id -> set of budgeted requests
+        self._budgeted_requests: set[str] = set()
+        self._last_drip_at = 0.0
+
+    def get_allowed_candidates(
+        self, request: LLMRequest, candidates: Sequence[Endpoint]
+    ) -> Sequence[Endpoint]:
+        fc = self.config
+
+        if request.request_id in self._budgeted_requests:
+            return candidates
+
+        rollout_id, char_len = self._get_rollout_request_id(request.body)
+        tokens_required = self._estimate_tokens_required(rollout_id, char_len, fc)
+
+        allowed = []
+        for c in candidates:
+            kv_cache_size = c.attributes.get("kv_cache_size", -1)
+            if kv_cache_size <= 0:  # type: ignore[operator]
+                continue
+
+            current_usage = self._replica_token_usage.get(c.name, 0)
+            if current_usage + tokens_required <= kv_cache_size:  # type: ignore[operator]
+                allowed.append(c)
+
+        if allowed:
+            return allowed
+
+        return self._get_drip_candidates(candidates, fc)
+
+    def _get_drip_candidates(self, candidates: Sequence[Endpoint], fc: dict) -> Sequence[Endpoint]:
+        enable_drip = fc.get("enable_drip", False)
+        if not enable_drip:
+            return []
+
+        drip_threshold_kv = fc.get("drip_threshold_kv", 0.1)
+        now = time.time()
+        drip_interval_s = fc.get("drip_interval_s", 2.0)
+        if (now - self._last_drip_at) >= drip_interval_s:
+            for c in candidates:
+                routing_stats = c.attributes.get("routing_stats", {})
+                physical_kv = routing_stats.get("kv", 1.0)  # type: ignore[attr-defined]
+                if physical_kv < drip_threshold_kv:
+                    self._last_drip_at = now
+                    print(f"[BUDGET] Drip Admission to {c.name} (Physical KV: {physical_kv:.2f})")
+                    return [c]
+        return []
+
+    def reserve(self, request: LLMRequest, selected: Endpoint) -> None:
+        fc = self.config
+
+        if request.request_id in self._budgeted_requests:
+            return
+
+        rollout_id, char_len = self._get_rollout_request_id(request.body)
+        tokens_required = self._estimate_tokens_required(rollout_id, char_len, fc)
+
+        self._replica_token_usage[selected.name] = (
+            self._replica_token_usage.get(selected.name, 0) + tokens_required
+        )
+        self._request_at_replica[request.request_id] = (
+            selected.name,
+            tokens_required,
+        )
+        self._budgeted_requests.add(request.request_id)
+        print(
+            f"[BUDGET] Admission committed for req={request.request_id} to replica={selected.name} "
+            f"(New Usage: {self._replica_token_usage[selected.name]})"
+        )
+
+    def release(self, request: LLMRequest, endpoint_name: str) -> None:
+        if request.request_id in self._request_at_replica:
+            replica_id_to_reclaim, tokens = self._request_at_replica.pop(request.request_id)
+            self._replica_token_usage[replica_id_to_reclaim] = max(
+                0,
+                self._replica_token_usage.get(replica_id_to_reclaim, 0) - tokens,
+            )
+            print(
+                f"[BUDGET] Released req={request.request_id} from replica={replica_id_to_reclaim} "
+                f"(New Usage: {self._replica_token_usage[replica_id_to_reclaim]})"
+            )
+            self._budgeted_requests.discard(request.request_id)
+
+    def update_learned_stats(self, rollout_request_id: str, isl: int, osl: int) -> None:
+        self._rollout_request_stats[rollout_request_id] = {
+            "isl": isl,
+            "osl": osl,
+        }
+        print(f"[BUDGET] Learned stats for rollout={rollout_request_id}: ISL={isl}, OSL={osl}")
+
+    def _get_rollout_request_id(self, body: Any) -> tuple[str, int]:  # noqa: ANN401
+        import struct
+        import uuid
+
+        NAMESPACE_FOR_UUID = uuid.uuid5(uuid.NAMESPACE_DNS, "llmd.inference.scheduler")  # noqa: N806
+
+        if not body:
+            return "", 0
+
+        try:
+            if isinstance(body, list) and len(body) > 0 and isinstance(body[0], int):
+                prompt_bytes = struct.pack(f"{len(body)}i", *body)
+                return (
+                    uuid.uuid5(NAMESPACE_FOR_UUID, prompt_bytes.hex()).hex,
+                    len(body) * 4,
+                )
+
+            if isinstance(body, (str, bytes)):
+                prompt_str = body if isinstance(body, str) else body.hex()
+                return (
+                    uuid.uuid5(NAMESPACE_FOR_UUID, prompt_str).hex,
+                    len(body),
+                )
+
+            if isinstance(body, list):
+                extracted_text = ""
+                for m in body:
+                    if isinstance(m, dict):
+                        extracted_text += str(m.get("content", ""))
+                    else:
+                        extracted_text += str(getattr(m, "content", ""))
+                char_len = len(extracted_text)
+                return (
+                    uuid.uuid5(NAMESPACE_FOR_UUID, extracted_text).hex,
+                    char_len,
+                )
+
+        except Exception as e:  # noqa: BLE001
+            print(f"[PLUGIN ERROR] Failed to parse request ID securely: {e}")
+
+        return "", 0
+
+    def _estimate_tokens_required(self, rollout_id: str, char_len: int, fc: dict) -> int:
+        stats = self._rollout_request_stats.get(rollout_id)
+        if stats:
+            return stats["isl"] + stats["osl"]
+
+        default_osl: int = fc.get("default_osl", 1024)
+        return (char_len // 4) + default_osl

--- a/scheduling/plugins/pickers/__init__.py
+++ b/scheduling/plugins/pickers/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Picker plugins."""
+
+from . import generic as generic_pickers  # noqa: F401
+from .generic import MaxScorePicker as MaxScorePicker
+from .generic import RandomPicker as RandomPicker

--- a/scheduling/plugins/scorers/__init__.py
+++ b/scheduling/plugins/scorers/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scorer plugins."""
+
+from . import backpressure as backpressure
+from . import generic as generic
+from . import prefix_plugin as prefix_plugin
+from .backpressure import (
+    KVCacheScorer as KVCacheScorer,
+)
+from .backpressure import (
+    LeastQueueScorer as LeastQueueScorer,
+)
+from .backpressure import (
+    QueueLengthScorer as QueueLengthScorer,
+)
+from .backpressure import (
+    RunningQueueScorer as RunningQueueScorer,
+)
+from .backpressure import (
+    WaitingQueueScorer as WaitingQueueScorer,
+)
+from .generic import ConstantScorer as ConstantScorer
+from .generic import RoundRobinScorer as RoundRobinScorer
+from .prefix_plugin import PrefixCacheScorer as PrefixCacheScorer

--- a/tests/unit/plugins/flow_control/test_kv_saturation.py
+++ b/tests/unit/plugins/flow_control/test_kv_saturation.py
@@ -1,0 +1,119 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from scheduling.framework import CycleState, Endpoint, LLMRequest
+from scheduling.plugins.flow_control.kv_saturation import KVSaturationPlugin
+
+
+class TestKVSaturationPlugin:
+    def setup_method(self):
+        self.config = {
+            "enable_drip": True,
+            "drip_threshold_kv": 0.2,
+            "drip_interval_s": 0.1,
+        }
+        self.plugin = KVSaturationPlugin(**self.config)
+        self.cycle_state = CycleState()
+        self.request = LLMRequest(request_id="test_req", body="test prompt")
+
+    def test_get_allowed_candidates_budget_ok(self):
+        """Test that candidates are allowed when budget is not exceeded."""
+        endpoints = [
+            Endpoint(name="ep1", attributes={"kv_cache_size": 2000}),
+            Endpoint(name="ep2", attributes={"kv_cache_size": 2000}),
+        ]
+
+        # No usage yet, should allow all
+        allowed = self.plugin.get_allowed_candidates(self.request, endpoints)
+        assert len(allowed) == 2
+        assert allowed[0].name == "ep1"
+        assert allowed[1].name == "ep2"
+
+    def test_get_allowed_candidates_budget_full(self):
+        """Test that candidates are blocked when budget is exceeded."""
+        endpoints = [
+            Endpoint(name="ep1", attributes={"kv_cache_size": 1000}),
+        ]
+
+        # Simulate usage full
+        self.plugin._replica_token_usage["ep1"] = 1000
+
+        # Request needs tokens (estimate > 0)
+        allowed = self.plugin.get_allowed_candidates(self.request, endpoints)
+        assert len(allowed) == 0
+
+    def test_reserve_and_release(self):
+        """Test that reserve and release update state correctly."""
+        endpoint = Endpoint(name="ep1", attributes={"kv_cache_size": 1000})
+
+        # Reserve
+        self.plugin.reserve(self.request, endpoint)
+        assert "ep1" in self.plugin._replica_token_usage
+        assert self.plugin._replica_token_usage["ep1"] > 0
+        assert self.request.request_id in self.plugin._budgeted_requests
+
+        # Release
+        self.plugin.release(self.request, "ep1")
+        assert self.plugin._replica_token_usage["ep1"] == 0
+        assert self.request.request_id not in self.plugin._budgeted_requests
+
+    def test_drip_admission(self):
+        """Test that drip admission allows a candidate even if budget is full."""
+        endpoints = [
+            Endpoint(name="ep1", attributes={"kv_cache_size": 1000, "routing_stats": {"kv": 0.1}}),
+        ]
+
+        # Simulate usage full
+        self.plugin._replica_token_usage["ep1"] = 1000
+
+        # Drip should allow it because physical KV (0.1) < threshold (0.2)
+        allowed = self.plugin.get_allowed_candidates(self.request, endpoints)
+        assert len(allowed) == 1
+        assert allowed[0].name == "ep1"
+
+    def test_drip_admission_blocked_by_threshold(self):
+        """Test that drip is blocked if physical KV is above threshold."""
+        endpoints = [
+            Endpoint(name="ep1", attributes={"kv_cache_size": 1000, "routing_stats": {"kv": 0.3}}),
+        ]
+
+        # Simulate usage full
+        self.plugin._replica_token_usage["ep1"] = 1000
+
+        # Drip should NOT allow it because physical KV (0.3) >= threshold (0.2)
+        allowed = self.plugin.get_allowed_candidates(self.request, endpoints)
+        assert len(allowed) == 0
+
+    def test_drip_admission_blocked_by_interval(self):
+        """Test that drip is blocked if called too frequently."""
+        endpoints = [
+            Endpoint(name="ep1", attributes={"kv_cache_size": 1000, "routing_stats": {"kv": 0.1}}),
+        ]
+
+        # Simulate usage full
+        self.plugin._replica_token_usage["ep1"] = 1000
+
+        # First drip should succeed
+        allowed = self.plugin.get_allowed_candidates(self.request, endpoints)
+        assert len(allowed) == 1
+
+        # Second drip immediately after should fail due to interval (0.1s)
+        allowed = self.plugin.get_allowed_candidates(self.request, endpoints)
+        assert len(allowed) == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Refactored flow control into a plugin type and added KVSaturation as a plugin for flow control.

-  ```scheduling/plugins/flow_control```:
    - This is where all flow control plugins can be found. Currently, only the ```KVSaturation``` plugin exists here.
-  ```scheduling/framework``` and ```scheduling/core```: 
    - Added config changes to allow for future flow control plugins
-   ```docs/kv_saturation.md```:
    - Updated doc with new instructions on how to enable the plugin with its different functions.
-  ```tests/unit/plugins/flow_control/test_kv_saturation.py```:
    - Added new test for KV Saturation flow control
- ```integration/rayserve/router.py```:
    - Refactored ```router.py``` to clean it and make it more modular.
    - All flow control tasks are now handled by ```FlowControlManager```. It handles all the Ray Actor pre-requisite work needed before offloading the work to the plugin. 
- ```configs/scheduler_config.yaml```:
    - Updated flow control config to the new plugin paradigm. 