### PR TITLE
fix: typo Addtionally -> Additionally in integration/verl/README.md

### DIFF
--- a/integration/verl/README.md
+++ b/integration/verl/README.md
@@ -261,4 +261,4 @@ Logs look as follows:
  - perf/throughput:2932.5070910595373
  ```
 
- Key metrics to look out for are ```perf/throughput``` for sampling throughput and ```timing_s/agent_loop/slowest/generate_sequences``` for your tail latency. Addtionally, if you enable preemptions, ```timing_s/agent_loop/slowest/num_preempted``` can be useful too. 
+ Key metrics to look out for are ```perf/throughput``` for sampling throughput and ```timing_s/agent_loop/slowest/generate_sequences``` for your tail latency. Additionally, if you enable preemptions, ```timing_s/agent_loop/slowest/num_preempted``` can be useful too. 


### PR DESCRIPTION
## 概要

#23 で nightly typo scan が報告した 1 件を修正します。

- `integration/verl/README.md:264`
- `Addtionally` → `Additionally`

issue 内の修正コマンド(`typos --write-changes .`)と同じ結果になります。

Closes #23

## 動作確認

- 変更は **1 行のみ**(`Addtionally` の 1 文字挿入で `Additionally` に)
- `grep -c "Addtionally"` 結果が **0** に
- gitleaks v8.30.1 で スキャン clean
- 他ファイル無変更