### PR TITLE
fix: correct 'independant' to 'independent' in verl_hook.py comment

### DIFF
--- a/integration/verl/verl_hook.py
+++ b/integration/verl/verl_hook.py
@@ -92,7 +92,7 @@ class InferenceSchedulerServerManager(AsyncLLMServerManager):
         # -- we cannot interleave metric tasks in between of scheduled tasks
         # -- due to python being FIFO.
         # -- so we just make it part of the scheduling task instead of
-        # -- having an independant metric poller task.
+        # -- having an independent metric poller task.
         async with self._scheduling_lock:
             tasks = [fetch_worker_metrics(ep, self.inflight_store) for ep in self.endpoints]
             await asyncio.gather(*tasks)


### PR DESCRIPTION
## Summary
Corrected typo in comment at :
- Before: `# -- having an independant metric poller task.`
- After: `# -- having an independent metric poller task.`

## Fixes
Fixes #32

## Checklist
- [x] One commit only
- [x] GH007 compliant (commit email: 166608075+Jah-yee@users.noreply.github.com)
- [x] No new tests needed (comment-only change)