### PR TITLE
feat: add reset() to PrefixIndexer and PrefixCacheScorer

### DIFF
--- a/scheduling/plugins/scorers/prefix_plugin.py
+++ b/scheduling/plugins/scorers/prefix_plugin.py
@@ -67,6 +67,15 @@ class PrefixIndexer:
                 # drop empty entry
                 self._hash_to_servers.pop(h, None)
 
+    def reset(self) -> None:
+        """Drop every cached hash->server and server->hashes mapping.
+
+        Useful when an external event (e.g. a vLLM weight reload) clears the
+        engine-side prefix cache, making every stored routing hint stale.
+        """
+        self._hash_to_servers.clear()
+        self._server_to_hashes.clear()
+
     def pods(self) -> list[str]:
         return list(self._server_to_hashes.keys())
 
@@ -206,3 +215,12 @@ class PrefixCacheScorer:
 
     def remove_server(self, server_name: str) -> None:
         self.indexer.remove_server(server_name)
+
+    def reset(self) -> None:
+        """Drop all cached prefix->server mappings.
+
+        Useful when an external event (e.g. a vLLM weight reload) clears the
+        engine-side prefix cache, making every stored routing hint stale; the
+        scorer should start over rather than score against invalid hints.
+        """
+        self.indexer.reset()

--- a/tests/unit/plugins/scorers/test_prefix_plugin.py
+++ b/tests/unit/plugins/scorers/test_prefix_plugin.py
@@ -39,6 +39,51 @@ def test_indexer_add_get_remove():
     assert idx.pods() == []
 
 
+def test_indexer_reset_clears_all_mappings():
+    idx = PrefixIndexer()
+    # Two servers share hash=2 so we exercise both maps and the shared-entry path.
+    idx.add([1, 2, 3], "s1")
+    idx.add([2, 3, 4], "s2")
+    assert set(idx.pods()) == {"s1", "s2"}
+    assert idx.get(2) == {"s1", "s2"}
+
+    idx.reset()
+
+    assert idx.pods() == []
+    for h in (1, 2, 3, 4):
+        assert idx.get(h) == set()
+
+    # After reset the indexer must still be usable.
+    idx.add([5], "s3")
+    assert idx.pods() == ["s3"]
+    assert idx.get(5) == {"s3"}
+
+
+def test_prefix_cache_scorer_reset_drops_routing_hints():
+    scorer = PrefixCacheScorer(block_size=4, max_prefix_blocks=10)
+    body = "abcdefghijkl"
+    req = LLMRequest(request_id="r1", target_model="m", headers={}, body=body)
+    hashes = _hash_prompt_bytes(req.target_model, body.encode("utf-8"), 4, 10)
+    assert len(hashes) >= 1
+    scorer.add_prefixes_for_server("ep1", hashes)
+
+    endpoints = {"ep1": Endpoint(name="ep1"), "ep2": Endpoint(name="ep2")}
+
+    # Pre-reset: ep1 has all the prefix hits, so it scores; ep2 does not.
+    pre_scores = scorer.score(CycleState(), req, endpoints)
+    assert "ep1" in pre_scores
+    assert pre_scores["ep1"] > 0.0
+
+    scorer.reset()
+
+    # Post-reset: no cached prefixes -> no endpoint scores against the prefix
+    # index. The "novel prompt" fallback then routes to the least-loaded
+    # servers; with both at zero load, both are tied.
+    post_scores = scorer.score(CycleState(), req, endpoints)
+    assert set(post_scores.keys()) == {"ep1", "ep2"}
+    assert scorer.indexer.pods() == []
+
+
 def test_hash_prompt_bytes_basic():
     body = "abcdefgh"
     # block size 4 -> two blocks


### PR DESCRIPTION
## Summary

Adds a small `reset()` method to `PrefixIndexer` and `PrefixCacheScorer` that drops every cached prefix-block → server mapping in one call, leaving the object reusable. Two new unit tests cover the indexer-level and scorer-level behavior.

## Motivation

The prefix-cache scorer keeps a `hash → server` index that mirrors the engine-side prefix cache and is used to steer subsequent requests with overlapping prompts to the same backend. The index is only valid as long as the engine-side cache it mirrors is intact.

When an external event invalidates the engine-side cache, every cached `prefix → server` hint becomes stale. The motivating case is a **vLLM weight reload** — after the reload, vLLM clears its engine-side prefix cache, but the same applies to any GPU-state reset that drops KV blocks. Continuing to honor the stored hints after such an event actively *hurts* hit rate: the scheduler keeps steering matching prompts at the same backend even though that backend no longer has the blocks they would have hit.

Today there's no public hook to clear the index, so callers either rebuild the whole scorer (awkward when it lives behind a stable plugin reference held by a long-running gateway) or reach into the private `_hash_to_servers` / `_server_to_hashes` dicts. This PR exposes a documented, supported way to do the same thing.

## Changes

- `PrefixIndexer.reset()` — `dict.clear()` on both the forward and reverse maps. After reset the indexer is still usable (re-`add()` works).
- `PrefixCacheScorer.reset()` — delegates to `indexer.reset()`. Documented use case is post-weight-reload state invalidation.
- `tests/unit/plugins/scorers/test_prefix_plugin.py`:
  - `test_indexer_reset_clears_all_mappings` — populates two servers (with one shared hash), resets, verifies both maps are empty for every previously-tracked hash, then re-adds and verifies the indexer still works.
  - `test_prefix_cache_scorer_reset_drops_routing_hints` — verifies a previously-favored endpoint loses its prefix-hit score advantage after reset.

No framework changes; this is a pure addition to an optional plugin (per the [`CONTRIBUTING.md`](https://github.com/llm-d-incubation/py-inference-scheduler/blob/main/CONTRIBUTING.md) plugin-vs-framework distinction).

## Real-world consumer

We use this in [`kinfer`](https://github.com/cohere-ai/kinfer), which vendors `scheduling/` and exposes a kinfer-side `LoadBalancerPolicy.reset_routing_state()` that fans the call out across roles after a successful `/resume` (i.e. once vLLM has finished broadcasting fresh weights). The kinfer-side glue is gateway-specific and stays out of upstream; `reset()` itself is generic and reusable.

## Test plan

- [x] `uv run ruff check` — passes
- [x] `uv run mypy scheduling datalayer integration tests` — passes (\"no issues found in 36 source files\")
- [x] `uv run pytest` — 35/35 passing, including the two new tests