### PR TITLE
feat: add sticky session scorer

### DIFF
--- a/scheduling/__init__.py
+++ b/scheduling/__init__.py
@@ -40,6 +40,7 @@ from .plugins import (
 )
 from .plugins.scorers.generic import RoundRobinScorer
 from .plugins.scorers.prefix_plugin import PrefixCacheScorer
+from .plugins.scorers.sticky_session import StickySessionScorer
 
 __all__ = [
     "CycleState",
@@ -57,5 +58,6 @@ __all__ = [
     "SchedulerProfile",
     "SchedulingResult",
     "ScoredEndpoint",
+    "StickySessionScorer",
     "WaitingQueueScorer",
 ]

--- a/scheduling/plugins/__init__.py
+++ b/scheduling/plugins/__init__.py
@@ -27,4 +27,5 @@ from .scorers import PrefixCacheScorer as PrefixCacheScorer
 from .scorers import QueueLengthScorer as QueueLengthScorer
 from .scorers import RoundRobinScorer as RoundRobinScorer
 from .scorers import RunningQueueScorer as RunningQueueScorer
+from .scorers import StickySessionScorer as StickySessionScorer
 from .scorers import WaitingQueueScorer as WaitingQueueScorer

--- a/scheduling/plugins/scorers/__init__.py
+++ b/scheduling/plugins/scorers/__init__.py
@@ -17,6 +17,7 @@
 from . import backpressure as backpressure
 from . import generic as generic
 from . import prefix_plugin as prefix_plugin
+from . import sticky_session as sticky_session
 from .backpressure import (
     KVCacheScorer as KVCacheScorer,
 )
@@ -35,3 +36,4 @@ from .backpressure import (
 from .generic import ConstantScorer as ConstantScorer
 from .generic import RoundRobinScorer as RoundRobinScorer
 from .prefix_plugin import PrefixCacheScorer as PrefixCacheScorer
+from .sticky_session import StickySessionScorer as StickySessionScorer

--- a/scheduling/plugins/scorers/sticky_session.py
+++ b/scheduling/plugins/scorers/sticky_session.py
@@ -1,0 +1,81 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import hashlib
+from typing import Mapping
+
+from scheduling.framework import (
+    CycleState,
+    Endpoint,
+    LLMRequest,
+    ScorerPlugin,
+    register_scorer,
+)
+
+
+@register_scorer("sticky_session")
+class StickySessionScorer(ScorerPlugin):
+    def __init__(self, header_name: str) -> None:
+        if not header_name.strip():
+            raise ValueError("Sticky session header name must be non-empty.")
+        self.header_name = header_name.strip().lower()
+
+    def score(
+        self,
+        cycle_state: CycleState,
+        request: LLMRequest,
+        pods: Mapping[str, Endpoint],
+    ) -> dict[str, float]:
+        if not pods:
+            return {}
+
+        session_id = _session_id_from_headers(request.headers, self.header_name)
+        if session_id is None:
+            return dict.fromkeys(pods.keys(), 0.0)
+
+        selected_name = max(
+            pods,
+            key=lambda name: _rendezvous_score(
+                session_id=session_id,
+                endpoint_name=name,
+            ),
+        )
+        scores = dict.fromkeys(pods.keys(), 0.0)
+        scores[selected_name] = 1.0
+        return scores
+
+
+def _session_id_from_headers(
+    headers: dict[str, str],
+    header_name: str,
+) -> str | None:
+    raw = next(
+        (value for key, value in headers.items() if key.lower() == header_name),
+        None,
+    )
+    if raw is None:
+        return None
+    session_id = raw.strip()
+    return session_id or None
+
+
+def _rendezvous_score(
+    *,
+    session_id: str,
+    endpoint_name: str,
+) -> int:
+    key = f"{session_id}\0{endpoint_name}".encode()
+    return int.from_bytes(hashlib.sha256(key).digest(), "big")

--- a/tests/unit/plugins/scorers/test_sticky_session.py
+++ b/tests/unit/plugins/scorers/test_sticky_session.py
@@ -1,0 +1,103 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from scheduling.framework import CycleState, Endpoint, LLMRequest, build_scorer
+from scheduling.plugins import StickySessionScorer
+
+_HEADER_NAME = "x-sticky-session"
+
+
+def _pods(*names: str) -> dict[str, Endpoint]:
+    return {name: Endpoint(name=name) for name in names}
+
+
+def _request(value: str | None) -> LLMRequest:
+    headers = {} if value is None else {_HEADER_NAME: value}
+    return LLMRequest(request_id="request-1", headers=headers)
+
+
+def _selected(scores: dict[str, float]) -> str:
+    selected = [name for name, score in scores.items() if score == 1.0]
+    assert len(selected) == 1
+    return selected[0]
+
+
+def test_sticky_session_requires_header_name():
+    with pytest.raises(ValueError, match="header name"):
+        StickySessionScorer(header_name="")
+
+
+def test_sticky_session_scores_empty_candidates():
+    scorer = StickySessionScorer(header_name=_HEADER_NAME)
+
+    assert scorer.score(CycleState(), _request("tenant-a"), {}) == {}
+
+
+def test_sticky_session_missing_or_empty_header_returns_zero_scores():
+    scorer = StickySessionScorer(header_name=_HEADER_NAME)
+    pods = _pods("ep1", "ep2")
+
+    assert scorer.score(CycleState(), _request(None), pods) == {"ep1": 0.0, "ep2": 0.0}
+    assert scorer.score(CycleState(), _request("   "), pods) == {"ep1": 0.0, "ep2": 0.0}
+
+
+def test_sticky_session_uses_case_insensitive_header_lookup():
+    scorer = StickySessionScorer(header_name="X-Sticky-Session")
+    pods = _pods("ep1", "ep2", "ep3")
+    lower = LLMRequest(request_id="request-1", headers={_HEADER_NAME: "tenant-a"})
+    mixed = LLMRequest(
+        request_id="request-1",
+        headers={"X-Sticky-Session": "tenant-a"},
+    )
+
+    lower_scores = scorer.score(CycleState(), lower, pods)
+    mixed_scores = scorer.score(CycleState(), mixed, pods)
+
+    assert lower_scores == mixed_scores
+
+
+def test_sticky_session_accepts_opaque_identifier_formats():
+    scorer = StickySessionScorer(header_name=_HEADER_NAME)
+    pods = _pods("ep1", "ep2", "ep3")
+    request = _request("tenant/a:chat#42")
+
+    first = scorer.score(CycleState(), request, pods)
+    second = scorer.score(CycleState(), request, pods)
+
+    assert first == second
+    assert set(first.values()) == {0.0, 1.0}
+
+
+def test_sticky_session_remaps_only_when_winner_is_removed():
+    scorer = StickySessionScorer(header_name=_HEADER_NAME)
+    pods = _pods("ep1", "ep2", "ep3", "ep4")
+    request = _request("tenant-a")
+
+    original = _selected(scorer.score(CycleState(), request, pods))
+    remaining = {name: endpoint for name, endpoint in pods.items() if name != original}
+    remapped = _selected(scorer.score(CycleState(), request, remaining))
+    restored = _selected(scorer.score(CycleState(), request, pods))
+
+    assert remapped != original
+    assert restored == original
+
+
+def test_sticky_session_can_be_built_from_registry():
+    scorer = build_scorer("sticky_session", header_name=_HEADER_NAME)
+
+    assert isinstance(scorer, StickySessionScorer)


### PR DESCRIPTION
Add a new `StickySessionScorer` that can be used to deterministically guide requests to specific pods based on a request header set by the client. The use-case is that for some RL workloads the client has full information about the prompt prefixes and can pre-arrange requests to maximize prefix cache hits in a way that would out-perform the current prefix cache scorer.

But there might be a better way to handle sticky sessions so if another approach is preferred please let me know