### PR TITLE
Mooncake KV Offload tier: request relocation

### DIFF
--- a/integration/rayserve/router.py
+++ b/integration/rayserve/router.py
@@ -15,12 +15,17 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import random
 import uuid
+from collections import OrderedDict
 from typing import Callable, Sequence
 
 from ray import serve
 from ray.actor import ActorHandle
+from ray.llm._internal.serve.core.configs.openai_api_models import (  # noqa: PLC2701
+    to_model_metadata,
+)
 from ray.llm._internal.serve.core.ingress.builder import (  # noqa: PLC2701
     LLMServingArgs,
     make_fastapi_ingress,
@@ -41,7 +46,21 @@ from ray.serve.request_router import (
 )
 
 from py_inference_scheduler.core.scheduler import Scheduler
+from py_inference_scheduler.datalayer.connectors.mooncake.kv import (
+    mooncake_enabled,
+    mooncake_engine_kwargs,
+    mooncake_env_vars,
+)
 from py_inference_scheduler.datalayer.rayserve.engine import MetricsAwareLLMServer
+from py_inference_scheduler.datalayer.rayserve.relocation import (
+    ENABLE_ENV as ENABLE_RELOCATION_ENV,
+)
+from py_inference_scheduler.datalayer.rayserve.relocation import (
+    PULL_OF_HEADER,
+    TARGET_HEADER,
+    RelocatingIngress,
+    relocation_enabled,
+)
 from py_inference_scheduler.framework import (
     Endpoint,
     FlowControlPlugin,
@@ -179,6 +198,11 @@ class IGWRouter(RequestRouter):
         self.deployment_name = deployment_id.name
         self.fc_manager = FlowControlManager(self)
         self._loop: asyncio.AbstractEventLoop | None = None
+        self._relocation_on = relocation_enabled()
+        self._request_replica: OrderedDict[str, str] = OrderedDict()
+        self._request_replica_cap = int(
+            os.environ.get("MOONCAKE_RELOCATION_REGISTRY_CAP", "4096")
+        )
 
     async def _get_routing_stats(
         self, replicas: list[RunningReplica], pending_request: PendingRequest
@@ -243,9 +267,34 @@ class IGWRouter(RequestRouter):
 
         target_model = getattr(request_args, "model", self.deployment_name)
 
-        return LLMRequest(request_id=req_id, body=body, target_model=target_model)
+        headers: dict[str, str] = {}
+        if len(pending_request.args) > 1 and pending_request.args[1] is not None:
+            headers = dict(getattr(pending_request.args[1], "headers", {}) or {})
 
-    async def choose_replicas(
+        return LLMRequest(
+            request_id=req_id, body=body, target_model=target_model, headers=headers
+        )
+
+    def _apply_relocation_headers(
+        self, headers: dict[str, str], candidate_replicas: list[RunningReplica]
+    ) -> tuple[RunningReplica | None, list[RunningReplica]]:
+        """Returns (target replica or None, remaining candidates)."""
+        if not self._relocation_on:
+            return None, candidate_replicas
+        # A pull must never land back on the replica it was pushed out of
+        pushed_from = self._request_replica.get(headers.get(PULL_OF_HEADER, ""))
+        if pushed_from and len(candidate_replicas) > 1:
+            candidate_replicas = [
+                r for r in candidate_replicas if str(r.replica_id) != pushed_from
+            ]
+        target_name = headers.get(TARGET_HEADER)
+        if target_name:
+            for replica in candidate_replicas:
+                if str(replica.replica_id) == target_name:
+                    return replica, candidate_replicas
+        return None, candidate_replicas
+
+    async def choose_replicas(  # noqa: PLR0911, PLR0912
         self,
         candidate_replicas: list[RunningReplica],
         pending_request: PendingRequest | None = None,
@@ -261,6 +310,12 @@ class IGWRouter(RequestRouter):
         # for health check empty requests
         if not pending_request or not pending_request.args or not llm_req.body:
             return self._fallback_random_choice(candidate_replicas)
+
+        target_replica, candidate_replicas = self._apply_relocation_headers(
+            llm_req.headers or {}, candidate_replicas
+        )
+        if target_replica:
+            return [[target_replica]]
 
         try:
             endpoints: Sequence[Endpoint] = await self.build_endpoints(
@@ -322,6 +377,14 @@ class IGWRouter(RequestRouter):
         llm_req = self._parse_to_llm_request(pending_request)
         is_streaming = pending_request.metadata.is_streaming
 
+        # Key=x-request-id since push and pull share the same Serve request_id
+        if self._relocation_on:
+            ingress_request_id = (llm_req.headers or {}).get("x-request-id")
+            if ingress_request_id:
+                self._request_replica[ingress_request_id] = str(replica_id)
+                if len(self._request_replica) > self._request_replica_cap:
+                    self._request_replica.popitem(last=False)
+
         if self.scheduler.has_flow_control():
             result.add_done_callback(lambda _: self.fc_manager.release(llm_req, str(replica_id)))
             self.fc_manager.attach_learning_callback(llm_req, result, is_streaming)
@@ -329,15 +392,40 @@ class IGWRouter(RequestRouter):
 
 # Hooking into Ray Serve's Request Router
 
+engine_kwargs: dict[str, object] = {
+    "enable_prefix_caching": True,
+    "tensor_parallel_size": 2,
+}
+env_vars: dict[str, str] = {
+    "NCCL_NET_PLUGIN": "/usr/local/gib/lib64/libnccl-net_internal.so",
+    "NCCL_CROSS_NIC": "0",
+    "NCCL_NET_GDR_LEVEL": "PIX",
+    "NCCL_P2P_NET_CHUNKSIZE": "131072",
+    "NCCL_NVLS_CHUNKSIZE": "524288",
+    "NCCL_IB_ADAPTIVE_ROUTING": "1",
+    "NCCL_IB_QPS_PER_CONNECTION": "4",
+    "NCCL_IB_TC": "52",
+    "NCCL_IB_FIFO_TC": "84",
+    "NCCL_TUNER_CONFIG_PATH": "/usr/local/gib/configs/tuner_config_a3u.txtpb",
+}
+
+# Opt-in Mooncake shared KV tier (set ENABLE_MOONCAKE_KV=1). Off by default so
+# the normal deployment is unchanged; when on, every replica pushes/pulls KV to a
+# cluster-wide Mooncake Store and saves decode KV via DecodeKVSavingConnector.
+if mooncake_enabled():
+    engine_kwargs.update(mooncake_engine_kwargs())
+    env_vars.update(mooncake_env_vars())
+
+# Pass through to engine side.
+if ENABLE_RELOCATION_ENV in os.environ:
+    env_vars[ENABLE_RELOCATION_ENV] = os.environ[ENABLE_RELOCATION_ENV]
+
 llm_config = LLMConfig(
     model_loading_config={
         "model_id": "qwen-32b",
         "model_source": "Qwen/Qwen2.5-32B-Instruct",
     },
-    engine_kwargs={
-        "enable_prefix_caching": True,
-        "tensor_parallel_size": 2,
-    },
+    engine_kwargs=engine_kwargs,
     deployment_config={
         "autoscaling_config": {
             "min_replicas": 1,
@@ -349,20 +437,7 @@ llm_config = LLMConfig(
         },
         "ray_actor_options": {"num_cpus": 1},
     },
-    runtime_env={
-        "env_vars": {
-            "NCCL_NET_PLUGIN": "/usr/local/gib/lib64/libnccl-net_internal.so",
-            "NCCL_CROSS_NIC": "0",
-            "NCCL_NET_GDR_LEVEL": "PIX",
-            "NCCL_P2P_NET_CHUNKSIZE": "131072",
-            "NCCL_NVLS_CHUNKSIZE": "524288",
-            "NCCL_IB_ADAPTIVE_ROUTING": "1",
-            "NCCL_IB_QPS_PER_CONNECTION": "4",
-            "NCCL_IB_TC": "52",
-            "NCCL_IB_FIFO_TC": "84",
-            "NCCL_TUNER_CONFIG_PATH": "/usr/local/gib/configs/tuner_config_a3u.txtpb",
-        }
-    },
+    runtime_env={"env_vars": env_vars},
 )
 
 
@@ -371,18 +446,33 @@ def build_custom_openai_app(builder_config: dict[str, object]) -> object:
     builder_args = LLMServingArgs.model_validate(builder_config)
     llm_configs = builder_args.llm_configs
 
-    llm_deployments = [
-        build_llm_deployment(c, deployment_cls=MetricsAwareLLMServer) for c in llm_configs
-    ]
+    llm_deployments = {
+        c.model_id: build_llm_deployment(c, deployment_cls=MetricsAwareLLMServer)
+        for c in llm_configs
+    }
+    model_cards = {c.model_id: to_model_metadata(c.model_id, c) for c in llm_configs}
+    lora_paths = {
+        c.model_id: c.lora_config.dynamic_lora_loading_path
+        for c in llm_configs
+        if c.lora_config is not None
+    }
 
     ingress_cls_config = builder_args.ingress_cls_config
-    ingress_options = ingress_cls_config.ingress_cls.get_deployment_options(llm_configs)
-    ingress_cls = make_fastapi_ingress(ingress_cls_config.ingress_cls)
+    base_ingress_cls = (
+        RelocatingIngress if relocation_enabled() else ingress_cls_config.ingress_cls
+    )
+    ingress_options = base_ingress_cls.get_deployment_options(llm_configs)
+    ingress_cls = make_fastapi_ingress(base_ingress_cls)
 
     return serve.deployment(
         ingress_cls,
         **ingress_options,
-    ).bind(llm_deployments=llm_deployments, **ingress_cls_config.ingress_extra_kwargs)
+    ).bind(
+        llm_deployments=llm_deployments,
+        model_cards=model_cards,
+        lora_paths=lora_paths,
+        **ingress_cls_config.ingress_extra_kwargs,
+    )
 
 
 app = build_custom_openai_app({

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,15 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
 
-# Skip following imports for third-party packages whose source uses Python 3.10+ syntax. 
+# Skip following imports for third-party packages whose source uses Python 3.10+ syntax.
 [[tool.mypy.overrides]]
 module = ["pytest.*", "ray.*"]
 follow_imports = "skip"
+
+# vllm is an engine-runtime dependency, never installed in the typecheck env.
+[[tool.mypy.overrides]]
+module = ["vllm.*"]
+ignore_missing_imports = true
 
 [tool.ruff]
 target-version = "py38"

--- a/src/py_inference_scheduler/datalayer/connectors/__init__.py
+++ b/src/py_inference_scheduler/datalayer/connectors/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/py_inference_scheduler/datalayer/connectors/mooncake/__init__.py
+++ b/src/py_inference_scheduler/datalayer/connectors/mooncake/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/py_inference_scheduler/datalayer/connectors/mooncake/decode_save.py
+++ b/src/py_inference_scheduler/datalayer/connectors/mooncake/decode_save.py
@@ -1,0 +1,122 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorMetadata,
+    KVConnectorRole,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.connector import (
+    MooncakeStoreConnector,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.data import (
+    MooncakeStoreConnectorMetadata,
+    ReqMeta,
+)
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import KVCacheConfig
+
+
+def should_save_decode_request(
+    *,
+    is_resumed: bool,
+    num_computed_tokens: int,
+    prefill_end_tokens: int,
+) -> bool:
+    """True only for decode since vllm already saves prefill."""
+    # is_resumed means vllm's own preemption-resume step (bulk block realloc,
+    # skipped for one step), not a relocated request - those save normally.
+    if is_resumed:
+        return False
+    return num_computed_tokens >= prefill_end_tokens
+
+
+class DecodeKVSavingConnector(MooncakeStoreConnector):
+    """
+    vllm only saves prompt KV to the store; this also saves decode KV.
+
+    So other replicas can reuse generated tokens. Enabled by save_decode_kv.
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        role: KVConnectorRole,
+        kv_cache_config: KVCacheConfig | None = None,
+    ) -> None:
+        super().__init__(vllm_config, role, kv_cache_config)
+        # extra_config values arrive as JSON bools or strings.
+        kv_transfer_config = vllm_config.kv_transfer_config
+        extra_config = (
+            kv_transfer_config.kv_connector_extra_config if kv_transfer_config else {}
+        )
+        value = extra_config.get("save_decode_kv", False)
+        self.save_decode_kv = value is True or str(value).lower() == "true"
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> KVConnectorMetadata:
+        meta = super().build_connector_meta(scheduler_output)
+        if not isinstance(meta, MooncakeStoreConnectorMetadata):
+            return meta  # upstream returned a different metadata type
+        if not self.save_decode_kv or self.kv_role == "kv_consumer":
+            return meta
+
+        sched = self.connector_scheduler
+        if sched is None:  # set for the scheduler role only
+            return meta
+        cached = scheduler_output.scheduled_cached_reqs
+        for i, req_id in enumerate(cached.req_ids):
+            new_block_ids = cached.new_block_ids[i]
+            if not new_block_ids:
+                continue
+            tracker = sched._request_trackers.get(req_id)
+            if tracker is None:
+                continue
+            if not should_save_decode_request(
+                is_resumed=req_id in cached.resumed_req_ids,
+                num_computed_tokens=cached.num_computed_tokens[i],
+                prefill_end_tokens=tracker.prefill_end_tokens,
+            ):
+                continue
+            req_tuple = sched._unfinished_requests.get(req_id)
+            if not req_tuple:
+                continue
+            unfinished_req = req_tuple[0]
+
+            # The stock scheduler only advances tracker.token_len on
+            # block-allocating steps, so in decode it lags the real token count;
+            true_token_len = (
+                cached.num_computed_tokens[i]
+                + scheduler_output.num_scheduled_tokens[req_id]
+            )
+            tracker.token_len = max(tracker.token_len, true_token_len)
+
+            tracker.update(new_block_ids)
+
+            # returns None until a new full block has completed.
+            req_meta = ReqMeta.from_request_tracker(
+                tracker,
+                sched._block_size,
+                load_spec=None,
+                skip_save=False,
+                block_hashes=unfinished_req.block_hashes,
+                is_last_chunk=False,
+                original_block_size=sched.original_block_size,
+            )
+            if req_meta is not None:
+                meta.add_request(req_meta)
+        return meta

--- a/src/py_inference_scheduler/datalayer/connectors/mooncake/kv.py
+++ b/src/py_inference_scheduler/datalayer/connectors/mooncake/kv.py
@@ -1,0 +1,58 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+
+ENABLE_ENV = "ENABLE_MOONCAKE_KV"
+
+# vLLM workers import the connector from this path.
+_CONNECTOR_MODULE = "py_inference_scheduler.datalayer.connectors.mooncake.decode_save"
+
+# Default when MOONCAKE_CONFIG_PATH is not set
+_DEFAULT_CONFIG_PATH = "/etc/mooncake/mooncake_config.json"
+
+
+def mooncake_enabled() -> bool:
+    return os.environ.get(ENABLE_ENV) == "1"
+
+
+def mooncake_engine_kwargs() -> dict:
+    # sha256_cbor is stable across Python versions and sha isn't.
+    return {
+        "kv_transfer_config": {
+            "kv_connector": "DecodeKVSavingConnector",
+            "kv_connector_module_path": _CONNECTOR_MODULE,
+            "kv_role": "kv_both",
+            "kv_connector_extra_config": {"save_decode_kv": True},
+        },
+        "prefix_caching_hash_algo": "sha256_cbor",
+    }
+
+
+def mooncake_env_vars() -> dict:
+    return {
+        # Seeds vLLM's block-hash chain; must match on every replica.
+        "PYTHONHASHSEED": "0",
+        "MOONCAKE_CONFIG_PATH": os.environ.get(
+            "MOONCAKE_CONFIG_PATH", _DEFAULT_CONFIG_PATH
+        ),
+        # Error out if no RDMA verbs device exists instead of silent TCP.
+        "MC_FORCE_HCA": "1",
+        # GKE COS nodes have no nvidia-peermem module that I found; GPU KV registration
+        # must go through the dmabuf path (ibv_reg_dmabuf_mr).
+        # removable for non GKE COS nodes that have peermem.
+        "WITH_NVIDIA_PEERMEM": "0",
+    }

--- a/src/py_inference_scheduler/datalayer/rayserve/engine.py
+++ b/src/py_inference_scheduler/datalayer/rayserve/engine.py
@@ -34,6 +34,7 @@ class DirectKVCacheLogger(StatLoggerBase):
         self,
         scheduler_stats: object,
         iteration_stats: object,
+        mm_cache_stats: object = None,
         engine_idx: int = 0,
     ) -> None:
         if self.target_dict is not None and scheduler_stats is not None:
@@ -73,10 +74,13 @@ class MetricsAwareVLLMEngine(VLLMEngine):
             return logger
 
         # Needed for injecting the logger
+        from vllm.config import VllmConfig  # type: ignore[import-not-found]
         from vllm.v1.engine.async_llm import AsyncLLM  # type: ignore[import-not-found]
         from vllm.v1.executor.abstract import Executor  # type: ignore[import-not-found]
 
-        engine_config.parallel_config.placement_group = pg  # type: ignore[attr-defined]
+        if not isinstance(engine_config, VllmConfig):
+            raise TypeError(f"expected VllmConfig, got {type(engine_config).__name__}")
+        engine_config.parallel_config.placement_group = pg
         executor_class = Executor.get_class(engine_config)
 
         # Return the engine client, passing the FACTORY instead of the instance

--- a/src/py_inference_scheduler/datalayer/rayserve/relocation.py
+++ b/src/py_inference_scheduler/datalayer/rayserve/relocation.py
@@ -1,0 +1,191 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import uuid
+
+from ray.llm._internal.serve.core.configs.openai_api_models import (  # noqa: PLC2701
+    CompletionRequest,
+    ErrorResponse,
+)
+from ray.llm._internal.serve.core.ingress.ingress import (  # noqa: PLC2701
+    DEFAULT_LLM_ROUTER_HTTP_TIMEOUT,
+    OpenAIHTTPException,
+    OpenAiIngress,
+    router_request_timeout,
+)
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+ENABLE_ENV = "ENABLE_MOONCAKE_RELOCATION"
+
+
+# Header and id names that travel inside relocation requests and responses.
+# Defined once here so the ingress, router, engine-side triggers, and clients
+# all use them identically.
+PULL_MARKER = "rls-pull-"  # id prefix labeling a request as a pull
+PULL_OF_HEADER = "x-rls-pull-of"  # on a pull: id of the request it continues
+TARGET_HEADER = "x-rls-target-replica"  # route this request to exactly this replica
+PUSH_PULL_HEADER = "x-rls-push-pull"  # on a response: the merged push and pull ids
+
+
+def relocation_enabled() -> bool:
+    return os.environ.get(ENABLE_ENV) == "1"
+
+
+def merge_completion_responses(push_response: dict, pull_response: dict) -> dict:
+    """One client response from the two halves.
+
+    The pushed request's partial output followed by the pull's continuation.
+    No recompute, just formatting the final object to look like what was
+    requested.
+    """
+    push_choice = push_response["choices"][0]
+    pull_choice = pull_response["choices"][0]
+
+    choice = dict(pull_choice)
+    choice["index"] = 0
+    choice["text"] = (push_choice.get("text") or "") + (pull_choice.get("text") or "")
+    if push_choice.get("token_ids") is not None:
+        choice["token_ids"] = list(push_choice["token_ids"]) + list(
+            pull_choice.get("token_ids") or []
+        )
+
+    merged = dict(pull_response)
+    merged["id"] = push_response["id"]
+    merged["created"] = push_response["created"]
+    merged["choices"] = [choice]
+    # The end client sent prompt p; the model produced d1 (before the abort)
+    # + d2 (after the pull). The pull's own usage claims prompt=p+d1 only
+    # because the ingress resubmitted d1 inside the pull's prompt, so prompt
+    # accounting must come from the push half.
+    merged["prompt_token_ids"] = push_response.get("prompt_token_ids")
+    push_usage = push_response.get("usage") or {}
+    pull_usage = pull_response.get("usage") or {}
+    if push_usage and pull_usage:
+        prompt_tokens = push_usage["prompt_tokens"]
+        completion_tokens = (
+            push_usage["completion_tokens"] + pull_usage["completion_tokens"]
+        )
+        merged["usage"] = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }
+    return merged
+
+
+def _strip_token_ids(response: dict) -> None:
+    response.pop("prompt_token_ids", None)
+    for choice in response.get("choices", []):
+        choice.pop("token_ids", None)
+        choice.pop("prompt_token_ids", None)
+
+
+def _with_headers(request: Request, extra: dict[str, str]) -> Request:
+    # Same synthetic-request shape as RawRequestInfo.to_starlette_request.
+    headers = {**dict(request.headers), **extra}
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "query_string": b"",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in headers.items()],
+    }
+    return Request(scope)
+
+
+class RelocatingIngress(OpenAiIngress):
+    """
+    Resubmits "aborted" requests as continuations on another replica.
+
+    Merges the two responses into one.
+    """
+
+    async def completions(self, body: CompletionRequest, request: Request) -> Response:
+        multi_prompt = (
+            isinstance(body.prompt, list)
+            and bool(body.prompt)
+            and isinstance(body.prompt[0], (str, list))
+        )
+        if (
+            not relocation_enabled()
+            or bool(body.stream)
+            or (body.n or 1) != 1
+            or multi_prompt
+        ):
+            return await super().completions(body, request)  # type: ignore[no-any-return]
+
+        client_wants_ids = bool(body.return_token_ids)
+        push_id = uuid.uuid4().hex
+        push_body = body.model_copy(update={"return_token_ids": True})
+
+        async with router_request_timeout(DEFAULT_LLM_ROUTER_HTTP_TIMEOUT):
+            push_response = await self._single_response(
+                push_body, request, {"x-request-id": push_id}
+            )
+            push_choice = push_response["choices"][0]
+            if push_choice.get("finish_reason") != "abort":
+                if not client_wants_ids:
+                    _strip_token_ids(push_response)
+                return JSONResponse(content=push_response)
+
+            prompt_ids = (
+                push_response.get("prompt_token_ids")
+                or push_choice.get("prompt_token_ids")
+                or []
+            )
+            generated_ids = push_choice.get("token_ids") or []
+            update: dict = {
+                "prompt": list(prompt_ids) + list(generated_ids),
+                "return_token_ids": True,
+            }
+            if body.max_tokens is not None:
+                update["max_tokens"] = max(1, body.max_tokens - len(generated_ids))
+            pull_body = body.model_copy(update=update)
+            pull_id = f"{PULL_MARKER}{uuid.uuid4().hex}"
+            pull_response = await self._single_response(
+                pull_body,
+                request,
+                {"x-request-id": pull_id, PULL_OF_HEADER: push_id},
+            )
+
+            merged = merge_completion_responses(push_response, pull_response)
+            if not client_wants_ids:
+                _strip_token_ids(merged)
+            return JSONResponse(
+                content=merged,
+                headers={PUSH_PULL_HEADER: f"{push_id},{pull_id}"},
+            )
+
+    async def _single_response(
+        self, body: CompletionRequest, request: Request, extra_headers: dict[str, str]
+    ) -> dict:
+        """Non-streaming completions yield exactly one response object."""
+        synthetic = _with_headers(request, extra_headers)
+        async for response in self._get_response(
+            body=body, call_method="completions", raw_request=synthetic
+        ):
+            if isinstance(response, ErrorResponse):
+                raise OpenAIHTTPException(
+                    message=response.error.message,
+                    status_code=response.error.code,
+                    type=response.error.type,
+                )
+            return response.model_dump()  # type: ignore[no-any-return]
+        raise OpenAIHTTPException(
+            message="empty response stream", status_code=500, type="InternalError"
+        )


### PR DESCRIPTION
> **Built on #46** - until that merges, this diff also shows the connector commits

The request-relocation machinery built on the shared KV tier from #46:

- **`rayserve/relocation.py`**:
    - `RelocatingIngress`: if a non-streaming completion returns `finish_reason: abort`, resubmit it as a continuation (prompt = prompt tokens + tokens generated so far) and merge the two responses into one. The client sees a single normal completion with exact usage accounting; an `x-rls-push-pull` response header carries the two request ids for attribution. Works because the #46 decode-save connector keeps an in-flight request's KV in the store at all times.
- **`router.py`**
    - Routes continuations. A continuation carries `x-rls-pull-of: <id of the aborted request>`; the router looks up which replica served that request and picks a different one. The decision on which replica is chosen can be added later based on the policy.`x-rls-target-replica` can force an exact replica instead - unused today, the entry point for future relocation policies.
    - Also restructures the deployment config slightly:
        - The engine/env dicts became variables (same values) so mooncake settings can be appended when ENABLE_MOONCAKE_KV=1`
        - The relocation flag is copied into the deployment's `runtime_env` because Ray Serve drops app-level env vars for deployments that define one.
        - The app builder now keys deployments by model id (required by ray 2.56) and uses `RelocatingIngress` only when relocation is enabled.
