### PR TITLE
Fix typo in VERL example

### DIFF
--- a/integration/verl/examples/verl-inference-scheduler.yaml
+++ b/integration/verl/examples/verl-inference-scheduler.yaml
@@ -28,7 +28,7 @@ spec:
         - name: ray-head
           image: verlai/verl:vllm011.latest
           imagePullPolicy: Always
-          # Optional, but reccommended; WANDB has a great UI
+          # Optional, but recommended; WANDB has a great UI
           # env:
           # - name: WANDB_API_KEY
           #   valueFrom:


### PR DESCRIPTION
Fixes #43.

Corrects `reccommended` to `recommended` in the VERL inference scheduler example.

Tests:
- `typos .`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0])' integration/verl/examples/verl-inference-scheduler.yaml`
