### PR TITLE
fix: correct typos found in ./integration/verl/examples/verl-inferenc…

### DIFF
--- a/integration/verl/examples/verl-inference-scheduler.yaml
+++ b/integration/verl/examples/verl-inference-scheduler.yaml
@@ -28,7 +28,7 @@ spec:
         - name: ray-head
           image: verlai/verl:vllm011.latest
           imagePullPolicy: Always
-          # Optional, but reccommended; WANDB has a great UI
+          # Optional, but recommended; WANDB has a great UI
           # env:
           # - name: WANDB_API_KEY
           #   valueFrom:


### PR DESCRIPTION
./integration/verl/examples/verl-inference-scheduler.yaml:31: `reccommended` -> `recommended`
