### PR TITLE
Adding Saturation filter

### DIFF
--- a/src/py_inference_scheduler/plugins/__init__.py
+++ b/src/py_inference_scheduler/plugins/__init__.py
@@ -15,6 +15,7 @@
 """Plugins for the scheduler."""
 
 # Re-export plugins from sub-packages to maintain backward compatibility
+from .filters import SaturationFilter as SaturationFilter
 from .flow_control import KVSaturationPlugin as KVSaturationPlugin
 from .handlers import SimpleFilter as SimpleFilter
 from .handlers import SingleProfileHandler as SingleProfileHandler

--- a/src/py_inference_scheduler/plugins/filters/__init__.py
+++ b/src/py_inference_scheduler/plugins/filters/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .saturation import SaturationFilter as SaturationFilter

--- a/src/py_inference_scheduler/plugins/filters/saturation.py
+++ b/src/py_inference_scheduler/plugins/filters/saturation.py
@@ -1,0 +1,81 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from typing import Mapping
+
+from py_inference_scheduler.framework import (
+    CycleState,
+    Endpoint,
+    FilterPlugin,
+    LLMRequest,
+    register_filter,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@register_filter("saturation")
+class SaturationFilter(FilterPlugin):
+    """Drops saturated endpoints from candidacy so affinity cannot elect them."""
+
+    def __init__(self, kv_threshold: float = 0.95, waiting_threshold: int = 16) -> None:
+        if not 0.0 < kv_threshold <= 1.0:
+            raise ValueError("kv_threshold must be in (0, 1].")
+        if waiting_threshold <= 0:
+            raise ValueError("waiting_threshold must be positive.")
+        self.kv_threshold = kv_threshold
+        self.waiting_threshold = waiting_threshold
+
+    def filter(
+        self,
+        cycle_state: CycleState,
+        request: LLMRequest,
+        pods: Mapping[str, Endpoint],
+    ) -> Mapping[str, Endpoint]:
+        eligible: dict[str, Endpoint] = {}
+        dropped: list[str] = []
+        for name, ep in pods.items():
+            stats = ep.attributes.get("routing_stats", {})
+            if not isinstance(stats, dict):
+                stats = {}
+            reason = self._saturation_reason(
+                kv=float(stats.get("kv", 0.0)),
+                waiting=int(stats.get("num_waiting_reqs", 0)),
+            )
+            if reason:
+                dropped.append(f"{name}({reason})")
+            else:
+                eligible[name] = ep
+
+        # A filter must never leave the ballot empty.
+        if not eligible:
+            logger.warning(
+                "all %d endpoints saturated: filter disabled for this decision", len(pods)
+            )
+            return pods
+        if dropped:
+            logger.info("saturation filter dropped %s", dropped)
+        return eligible
+
+    def _saturation_reason(self, *, kv: float, waiting: int) -> str | None:
+        """Which threshold(s) fired, or None if the endpoint is healthy."""
+        reasons = []
+        if kv >= self.kv_threshold:
+            reasons.append(f"kv={kv:.2f}")
+        if waiting >= self.waiting_threshold:
+            reasons.append(f"waiting={waiting}")
+        return ",".join(reasons) if reasons else None

--- a/src/py_inference_scheduler/plugins/filters/saturation.py
+++ b/src/py_inference_scheduler/plugins/filters/saturation.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 @register_filter("saturation")
 class SaturationFilter(FilterPlugin):
-    """Drops saturated endpoints from candidacy so affinity cannot elect them."""
+    """Drops saturated endpoints that are >= saturation threshold."""
 
     def __init__(self, kv_threshold: float = 0.95, waiting_threshold: int = 16) -> None:
         if not 0.0 < kv_threshold <= 1.0:

--- a/tests/unit/plugins/filters/__init__.py
+++ b/tests/unit/plugins/filters/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/plugins/filters/test_saturation.py
+++ b/tests/unit/plugins/filters/test_saturation.py
@@ -1,0 +1,81 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from py_inference_scheduler.framework import CycleState, Endpoint, LLMRequest
+from py_inference_scheduler.plugins import SaturationFilter
+
+
+def _ep(name: str, kv: float = 0.0, waiting: int = 0) -> Endpoint:
+    return Endpoint(
+        name=name,
+        attributes={"routing_stats": {"kv": kv, "num_waiting_reqs": waiting}},
+    )
+
+
+def _run(flt: SaturationFilter, pods: dict[str, Endpoint]) -> dict[str, Endpoint]:
+    return dict(flt.filter(CycleState(), LLMRequest(request_id="r"), pods))
+
+
+def test_drops_saturated_keeps_healthy():
+    flt = SaturationFilter(kv_threshold=0.9, waiting_threshold=16)
+    pods = {
+        "hot_kv": _ep("hot_kv", kv=0.95),
+        "deep_queue": _ep("deep_queue", waiting=40),
+        "ok": _ep("ok", kv=0.4, waiting=3),
+    }
+    assert set(_run(flt, pods)) == {"ok"}
+
+
+def test_thresholds_are_inclusive():
+    flt = SaturationFilter(kv_threshold=0.9, waiting_threshold=16)
+    pods = {
+        "at_kv": _ep("at_kv", kv=0.9),
+        "at_waiting": _ep("at_waiting", waiting=16),
+        "under": _ep("under", kv=0.89, waiting=15),
+    }
+    assert set(_run(flt, pods)) == {"under"}
+
+
+def test_all_saturated_returns_full_set():
+    """A filter must never leave the ballot empty."""
+    flt = SaturationFilter(kv_threshold=0.9, waiting_threshold=16)
+    pods = {name: _ep(name, kv=0.99, waiting=99) for name in ("a", "b", "c")}
+    assert set(_run(flt, pods)) == {"a", "b", "c"}
+
+
+def test_missing_stats_counts_as_healthy():
+    flt = SaturationFilter()
+    pods = {"fresh": Endpoint(name="fresh"), "hot": _ep("hot", kv=0.99)}
+    assert set(_run(flt, pods)) == {"fresh"}
+
+
+def test_invalid_config_rejected():
+    with pytest.raises(ValueError, match="kv_threshold"):
+        SaturationFilter(kv_threshold=0.0)
+    with pytest.raises(ValueError, match="kv_threshold"):
+        SaturationFilter(kv_threshold=1.5)
+    with pytest.raises(ValueError, match="waiting_threshold"):
+        SaturationFilter(waiting_threshold=0)
+
+
+def test_drop_log_includes_reason():
+    flt = SaturationFilter(kv_threshold=0.9, waiting_threshold=16)
+    assert flt._saturation_reason(kv=0.95, waiting=2) == "kv=0.95"
+    assert flt._saturation_reason(kv=0.1, waiting=40) == "waiting=40"
+    assert flt._saturation_reason(kv=0.95, waiting=40) == "kv=0.95,waiting=40"
+    assert flt._saturation_reason(kv=0.5, waiting=3) is None


### PR DESCRIPTION
- Saturation filter that uses live **KV Utilization** and **Waiting Queue** thresholds to decide if an endpoint is eligible to be chosen for routing
- If all eps are saturated, filter is **non-blocking** and adds all of them to the routable pool. 
- Useful for breaking sticky routing seen mostly in **Prefix Cache** scoring and sometimes in **Sticky Session** too