### PR TITLE
Background metrics polling for Slime integration

### DIFF
--- a/integration/slime/README.md
+++ b/integration/slime/README.md
@@ -20,7 +20,7 @@ full ownership of the rollout lifecycle; we only decide which engine serves each
 Key components:
 - [server.py](./server.py): the router — worker registry + the scheduled `/generate` proxy.
 - [`__main__.py`](./__main__.py): the `python -m integration.slime` launcher.
-- [datalayer/metrics/refresher.py](../../src/py_inference_scheduler/datalayer/metrics/refresher.py): background poller updating `routing_stats` periodically.
+- [datalayer/metrics/poller.py](../../src/py_inference_scheduler/datalayer/metrics/poller.py): background poller updating `routing_stats` periodically.
 - [datalayer/metrics/slime/](../../src/py_inference_scheduler/datalayer/metrics/slime): parses Prometheus `/metrics`.
 
 ---

--- a/integration/slime/README.md
+++ b/integration/slime/README.md
@@ -13,14 +13,15 @@ implemented. It may require updates for other slime / sgl-router versions.
 slime manages its own SGLang rollout engines and, by default, launches its own sgl-router to load
 balance across them. When you set `--sglang-router-ip/--sglang-router-port`, slime skips that router
 and instead each engine self-registers with ours (`POST /workers`) and the rollout posts generations
-to it (`POST /generate`). On each request the router scrapes the engines' Prometheus `/metrics` and
-delegates the routing decision to the `py-inference-scheduler`. slime keeps
+to it (`POST /generate`). The router polls the engines' Prometheus `/metrics` and delegates each routing decision to the
+`py-inference-scheduler`. slime keeps
 full ownership of the rollout lifecycle; we only decide which engine serves each request.
 
 Key components:
 - [server.py](./server.py): the router — worker registry + the scheduled `/generate` proxy.
 - [`__main__.py`](./__main__.py): the `python -m integration.slime` launcher.
-- [datalayer/metrics/slime/](../../datalayer/metrics/slime): per-request Prometheus `/metrics` scrape.
+- [datalayer/metrics/refresher.py](../../src/py_inference_scheduler/datalayer/metrics/refresher.py): background poller updating `routing_stats` periodically.
+- [datalayer/metrics/slime/](../../src/py_inference_scheduler/datalayer/metrics/slime): parses Prometheus `/metrics`.
 
 ---
 
@@ -66,11 +67,11 @@ The command is the same for single- and multi-node — run it on the single VM f
 worker nodes.
 
 ```bash
-python -m integration.slime --host 0.0.0.0 --port 8000
+python -m integration.slime --host 0.0.0.0 --port 8000 --metrics-refresh-ms 100
 ```
 
 It uses the bundled `examples/scheduler.yaml` by default; pass `--config /path/to/your.yaml` to
-override with a custom policy.
+override with a custom policy. The poll intervals for metrics is set by `--metrics-refresh-ms`(default is 100ms).
 
 Then point slime at it — the **only** change to slime's launch is two flags:
 

--- a/integration/slime/__main__.py
+++ b/integration/slime/__main__.py
@@ -30,13 +30,12 @@ from py_inference_scheduler.core.config import SchedulerConfig
 _DEFAULT_CONFIG = "integration/slime/examples/scheduler.yaml"
 
 
-def run(
-    create_app: Callable[[Scheduler], FastAPI],
-    *,
+def build_parser(
     description: str,
     framework: str,
     default_config: str = _DEFAULT_CONFIG,
-) -> None:
+    add_args: Callable[[argparse.ArgumentParser], None] | None = None,
+) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument("--host", default="0.0.0.0", help="bind address")  # noqa: S104
     parser.add_argument("--port", type=int, default=8000, help="bind port")
@@ -51,7 +50,20 @@ def run(
         default="scheduler",
         help=f"process title; keeps the scheduler out of {framework}'s `pkill -9 python` cleanup",
     )
-    args = parser.parse_args()
+    if add_args is not None:
+        add_args(parser)
+    return parser
+
+
+def run(
+    create_app: Callable[[Scheduler, argparse.Namespace], FastAPI],
+    *,
+    description: str,
+    framework: str,
+    default_config: str = _DEFAULT_CONFIG,
+    add_args: Callable[[argparse.ArgumentParser], None] | None = None,
+) -> None:
+    args = build_parser(description, framework, default_config, add_args).parse_args()
 
     # These frameworks' run scripts begin with `pkill -9 python` ("for rerun the task"), which
     # would kill this scheduler (a python process). Renaming the process so that cleanup misses it
@@ -71,12 +83,30 @@ def run(
     config = SchedulerConfig.from_dict(config_dict)
     logging.getLogger(__name__).info("Loaded scheduler config: %s", config)
 
-    app = create_app(Scheduler.new_with_config(config))
+    app = create_app(Scheduler.new_with_config(config), args)
     uvicorn.run(app, host=args.host, port=args.port, log_level=args.log_level)
 
 
+def _add_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--metrics-refresh-ms",
+        type=int,
+        default=100,
+        help="worker /metrics polling interval for the MetricsRefresher",
+    )
+
+
+def _app(scheduler: Scheduler, args: argparse.Namespace) -> FastAPI:
+    return create_app(scheduler, metrics_refresh_ms=args.metrics_refresh_ms)
+
+
 def main() -> None:
-    run(create_app, description="sampling scheduler for slime", framework="slime")
+    run(
+        _app,
+        description="sampling scheduler for slime",
+        framework="slime",
+        add_args=_add_args,
+    )
 
 
 if __name__ == "__main__":

--- a/integration/slime/__main__.py
+++ b/integration/slime/__main__.py
@@ -92,7 +92,7 @@ def _add_args(parser: argparse.ArgumentParser) -> None:
         "--metrics-refresh-ms",
         type=int,
         default=100,
-        help="worker /metrics polling interval for the MetricsRefresher",
+        help="worker /metrics polling interval for the MetricsPoller",
     )
 
 

--- a/integration/slime/server.py
+++ b/integration/slime/server.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 # Headers that must not be forwarded verbatim when proxying to a worker.
 _HOP_BY_HOP = {"host", "content-length", "transfer-encoding", "connection"}
+_METRIC_STALENESS_CADENCE = 10
 
 # Returns the prompt the scheduler routes on
 RoutingBody = Callable[[dict], object]
@@ -217,7 +218,7 @@ def create_app(scheduler: Scheduler, metrics_refresh_ms: int = 100) -> FastAPI:
         staleness = poller.staleness()
         if staleness > stale_after:
             now = time.monotonic()
-            if now - app.state.last_stale_warn > 10:  # noqa: PLR2004
+            if now - app.state.last_stale_warn > _METRIC_STALENESS_CADENCE * stale_after:
                 logger.warning("routing on stale metrics: snapshot %.2fs old", staleness)
                 app.state.last_stale_warn = now
         return await schedule_and_proxy(

--- a/integration/slime/server.py
+++ b/integration/slime/server.py
@@ -17,8 +17,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 import uuid
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 
 import aiohttp
@@ -27,6 +28,7 @@ from fastapi.responses import JSONResponse
 
 from py_inference_scheduler import Scheduler
 from py_inference_scheduler.datalayer.metrics.datastore import InflightStore
+from py_inference_scheduler.datalayer.metrics.refresher import FetchMetrics, MetricsRefresher
 from py_inference_scheduler.datalayer.metrics.slime.sglang import fetch_worker_metrics
 from py_inference_scheduler.framework import Endpoint, LLMRequest
 
@@ -35,8 +37,6 @@ logger = logging.getLogger(__name__)
 # Headers that must not be forwarded verbatim when proxying to a worker.
 _HOP_BY_HOP = {"host", "content-length", "transfer-encoding", "connection"}
 
-# populates ep.attributes from the worker's /metrics.
-FetchMetrics = Callable[[Endpoint, InflightStore, aiohttp.ClientSession], Awaitable[None]]
 # Returns the prompt the scheduler routes on
 RoutingBody = Callable[[dict], object]
 
@@ -104,7 +104,7 @@ async def schedule_and_proxy(  # noqa: PLR0913
     inflight: InflightStore,
     scheduling_lock: asyncio.Lock,
     scheduler: Scheduler,
-    fetch_metrics: FetchMetrics,
+    fetch_metrics: FetchMetrics | None,
     routing_body: RoutingBody,
     generate_path: str,
 ) -> Response:
@@ -118,10 +118,13 @@ async def schedule_and_proxy(  # noqa: PLR0913
 
     session: aiohttp.ClientSession = request.app.state.http
 
-    # Metrics scrape + scheduling happen ON the request path under a lock
-    # [check verl_hook.py:L90-95 for why they happen in the same task]
+    # fetch_metrics=None means a MetricsRefresher keeps routing_stats fresh off
+    # the request path and the lock only serializes the scheduling decision.
+    # On-path scraping under the lock throttles admission below engine intake
+    # (measured: +24% rollout wall-clock at identical policy).
     async with scheduling_lock:
-        await asyncio.gather(*[fetch_metrics(ep, inflight, session) for ep in endpoints])
+        if fetch_metrics is not None:
+            await asyncio.gather(*[fetch_metrics(ep, inflight, session) for ep in endpoints])
         selected = scheduler.run(llm_req, candidates=endpoints)
         if not selected:
             return JSONResponse(status_code=503, content={"error": "no worker selected"})
@@ -169,13 +172,28 @@ def register_worker_routes(app: FastAPI, registry: WorkerRegistry) -> None:
         return JSONResponse(content={"workers": registry.list_workers_as_dicts()})
 
 
-def create_app(scheduler: Scheduler) -> FastAPI:
+def create_app(scheduler: Scheduler, metrics_refresh_ms: int = 100) -> FastAPI:
     """Build the slime router FastAPI app around a configured Scheduler."""
     registry = WorkerRegistry()
     inflight = InflightStore()
     scheduling_lock = asyncio.Lock()
+    refresher = MetricsRefresher(
+        registry.endpoints, inflight, fetch_worker_metrics, interval_ms=metrics_refresh_ms
+    )
 
-    app = FastAPI(title="slime sampling router", lifespan=lifespan)
+    @asynccontextmanager
+    async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
+        refresher.start()
+        try:
+            async with lifespan(app):
+                yield
+        finally:
+            refresher.stop()
+
+    app = FastAPI(title="slime sampling router", lifespan=_lifespan)
+    app.state.refresher = refresher
+    app.state.last_stale_warn = 0.0
+    stale_after = max(0.5, 5 * metrics_refresh_ms / 1000.0)
 
     register_worker_routes(app, registry)
 
@@ -188,13 +206,19 @@ def create_app(scheduler: Scheduler) -> FastAPI:
 
     @app.post("/generate")
     async def generate(request: Request) -> Response:
+        staleness = refresher.staleness()
+        if staleness > stale_after:
+            now = time.monotonic()
+            if now - app.state.last_stale_warn > 10:  # noqa: PLR2004
+                logger.warning("routing on stale metrics: snapshot %.2fs old", staleness)
+                app.state.last_stale_warn = now
         return await schedule_and_proxy(
             request,
             registry=registry,
             inflight=inflight,
             scheduling_lock=scheduling_lock,
             scheduler=scheduler,
-            fetch_metrics=fetch_worker_metrics,
+            fetch_metrics=None,
             routing_body=_routing_body,
             generate_path="/generate",
         )

--- a/integration/slime/server.py
+++ b/integration/slime/server.py
@@ -87,7 +87,12 @@ def _safe_json(raw: bytes) -> dict:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """Shared aiohttp session: unbounded connections + no per-request timeout."""
+    """Shared aiohttp session: unbounded connections + no per-request timeout.
+
+    vime uses this directly as its app lifespan; slime wraps it (create_app's
+    _lifespan) to add the MetricsRefresher start/stop around it.
+    The latter will be vime's default mode in the future.
+    """
     # limit=0 removes aiohttp's default 100-connection cap so requests fan out across engines.
     connector = aiohttp.TCPConnector(limit=0)
     # total=None lifts aiohttp's default 300s cap per generation
@@ -108,7 +113,13 @@ async def schedule_and_proxy(  # noqa: PLR0913
     routing_body: RoutingBody,
     generate_path: str,
 ) -> Response:
-    """Scrape metrics under a lock, pick a worker, and proxy the request to it."""
+    """Pick a worker under the scheduling lock and proxy the request to it.
+
+    If fetch_metrics is given, every endpoint's metrics are scraped inside this
+    request before scheduling (vime's mode). If it is None, scheduling reads
+    the routing_stats a background MetricsRefresher keeps fresh (slime's mode).
+    Vime will be changed to follow slime's request path soon.
+    """
     raw = await request.body()
     llm_req = LLMRequest(request_id=uuid.uuid4().hex, body=routing_body(_safe_json(raw)))
 
@@ -118,10 +129,6 @@ async def schedule_and_proxy(  # noqa: PLR0913
 
     session: aiohttp.ClientSession = request.app.state.http
 
-    # fetch_metrics=None means a MetricsRefresher keeps routing_stats fresh off
-    # the request path and the lock only serializes the scheduling decision.
-    # On-path scraping under the lock throttles admission below engine intake
-    # (measured: +24% rollout wall-clock at identical policy).
     async with scheduling_lock:
         if fetch_metrics is not None:
             await asyncio.gather(*[fetch_metrics(ep, inflight, session) for ep in endpoints])
@@ -183,6 +190,7 @@ def create_app(scheduler: Scheduler, metrics_refresh_ms: int = 100) -> FastAPI:
 
     @asynccontextmanager
     async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
+        """Run the refresher for the app's lifetime, around the shared-session lifespan."""
         refresher.start()
         try:
             async with lifespan(app):

--- a/integration/slime/server.py
+++ b/integration/slime/server.py
@@ -28,7 +28,7 @@ from fastapi.responses import JSONResponse
 
 from py_inference_scheduler import Scheduler
 from py_inference_scheduler.datalayer.metrics.datastore import InflightStore
-from py_inference_scheduler.datalayer.metrics.refresher import FetchMetrics, MetricsRefresher
+from py_inference_scheduler.datalayer.metrics.poller import FetchMetrics, MetricsPoller
 from py_inference_scheduler.datalayer.metrics.slime.sglang import fetch_worker_metrics
 from py_inference_scheduler.framework import Endpoint, LLMRequest
 
@@ -90,7 +90,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Shared aiohttp session: unbounded connections + no per-request timeout.
 
     vime uses this directly as its app lifespan; slime wraps it (create_app's
-    _lifespan) to add the MetricsRefresher start/stop around it.
+    _lifespan) to add the MetricsPoller start/stop around it.
     The latter will be vime's default mode in the future.
     """
     # limit=0 removes aiohttp's default 100-connection cap so requests fan out across engines.
@@ -117,7 +117,7 @@ async def schedule_and_proxy(  # noqa: PLR0913
 
     If fetch_metrics is given, every endpoint's metrics are scraped inside this
     request before scheduling (vime's mode). If it is None, scheduling reads
-    the routing_stats a background MetricsRefresher keeps fresh (slime's mode).
+    the routing_stats a background MetricsPoller keeps fresh (slime's mode).
     Vime will be changed to follow slime's request path soon.
     """
     raw = await request.body()
@@ -184,22 +184,22 @@ def create_app(scheduler: Scheduler, metrics_refresh_ms: int = 100) -> FastAPI:
     registry = WorkerRegistry()
     inflight = InflightStore()
     scheduling_lock = asyncio.Lock()
-    refresher = MetricsRefresher(
+    poller = MetricsPoller(
         registry.endpoints, inflight, fetch_worker_metrics, interval_ms=metrics_refresh_ms
     )
 
     @asynccontextmanager
     async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
-        """Run the refresher for the app's lifetime, around the shared-session lifespan."""
-        refresher.start()
+        """Run the poller for the app's lifetime, around the shared-session lifespan."""
+        poller.start()
         try:
             async with lifespan(app):
                 yield
         finally:
-            refresher.stop()
+            poller.stop()
 
     app = FastAPI(title="slime sampling router", lifespan=_lifespan)
-    app.state.refresher = refresher
+    app.state.poller = poller
     app.state.last_stale_warn = 0.0
     stale_after = max(0.5, 5 * metrics_refresh_ms / 1000.0)
 
@@ -214,7 +214,7 @@ def create_app(scheduler: Scheduler, metrics_refresh_ms: int = 100) -> FastAPI:
 
     @app.post("/generate")
     async def generate(request: Request) -> Response:
-        staleness = refresher.staleness()
+        staleness = poller.staleness()
         if staleness > stale_after:
             now = time.monotonic()
             if now - app.state.last_stale_warn > 10:  # noqa: PLR2004

--- a/integration/vime/__main__.py
+++ b/integration/vime/__main__.py
@@ -14,12 +14,21 @@
 
 from __future__ import annotations
 
+import argparse
+
+from fastapi import FastAPI
+
 from integration.slime.__main__ import run
 from integration.vime.server import create_app
+from py_inference_scheduler import Scheduler
+
+
+def _app(scheduler: Scheduler, args: argparse.Namespace) -> FastAPI:
+    return create_app(scheduler)
 
 
 def main() -> None:
-    run(create_app, description="sampling scheduler for vime", framework="vime")
+    run(_app, description="sampling scheduler for vime", framework="vime")
 
 
 if __name__ == "__main__":

--- a/src/py_inference_scheduler/datalayer/metrics/poller.py
+++ b/src/py_inference_scheduler/datalayer/metrics/poller.py
@@ -32,7 +32,7 @@ FetchMetrics = Callable[[Endpoint, InflightStore, aiohttp.ClientSession], Awaita
 _REPORT_EVERY_S = 30.0
 
 
-class MetricsRefresher:
+class MetricsPoller:
     """Keeps routing_stats fresh by polling worker metrics off the request path.
 
     Runs in its own thread with a private event loop, so a busy serving loop
@@ -53,7 +53,7 @@ class MetricsRefresher:
         self._interval = interval_ms / 1000.0
         self._last_refresh = 0.0
         self._stop = threading.Event()
-        self._thread = threading.Thread(target=self._run, name="metrics-refresher", daemon=True)
+        self._thread = threading.Thread(target=self._run, name="metrics-poller", daemon=True)
 
     def start(self) -> None:
         self._thread.start()
@@ -87,13 +87,13 @@ class MetricsRefresher:
                     now = time.monotonic()
                     if failures and now - last_report > _REPORT_EVERY_S:
                         logger.warning(
-                            "metrics-refresher: %d/%d fetches failed (first: %r)",
+                            "metrics-poller: %d/%d fetches failed (first: %r)",
                             len(failures), len(endpoints), failures[0],
                         )
                         last_report = now
                     elif now - last_report > _REPORT_EVERY_S:
                         logger.info(
-                            "metrics-refresher: %d endpoints, scrape %.0fms, interval %.0fms",
+                            "metrics-poller: %d endpoints, scrape %.0fms, interval %.0fms",
                             len(endpoints), (now - started) * 1000, self._interval * 1000,
                         )
                         last_report = now

--- a/src/py_inference_scheduler/datalayer/metrics/poller.py
+++ b/src/py_inference_scheduler/datalayer/metrics/poller.py
@@ -29,15 +29,18 @@ logger = logging.getLogger(__name__)
 
 FetchMetrics = Callable[[Endpoint, InflightStore, aiohttp.ClientSession], Awaitable[None]]
 
-_REPORT_EVERY_S = 30.0
+_LOG_CADENCE = 300
 
 
 class MetricsPoller:
-    """Keeps routing_stats fresh by polling worker metrics off the request path.
+    """Polls worker metrics in the background at a set interval.
 
-    Runs in its own thread with a private event loop, so a busy serving loop
-    can neither starve the polling nor receive any of its I/O. Updates are
-    atomic reference swaps; `staleness()` reports the snapshot's age.
+    Runs in its own thread with a private event loop, so the serving loop can
+    neither starve the polling nor receive any of its I/O.
+
+    WARNING: the thread shares the GIL, so the poll must stay I/O-bound.
+    CPU-bound work here can delay routing decisions.
+    staleness() returns the snapshot's age.
     """
 
     def __init__(
@@ -69,7 +72,8 @@ class MetricsPoller:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         session = loop.run_until_complete(self._make_session())
-        last_report = 0.0
+        last_log = 0.0
+        log_interval = _LOG_CADENCE * self._interval
         try:
             while not self._stop.is_set():
                 started = time.monotonic()
@@ -85,18 +89,18 @@ class MetricsPoller:
                     if len(failures) < len(endpoints):
                         self._last_refresh = time.monotonic()
                     now = time.monotonic()
-                    if failures and now - last_report > _REPORT_EVERY_S:
+                    if failures and now - last_log > log_interval:
                         logger.warning(
                             "metrics-poller: %d/%d fetches failed (first: %r)",
                             len(failures), len(endpoints), failures[0],
                         )
-                        last_report = now
-                    elif now - last_report > _REPORT_EVERY_S:
+                        last_log = now
+                    elif now - last_log > log_interval:
                         logger.info(
                             "metrics-poller: %d endpoints, scrape %.0fms, interval %.0fms",
                             len(endpoints), (now - started) * 1000, self._interval * 1000,
                         )
-                        last_report = now
+                        last_log = now
                 self._stop.wait(max(0.0, self._interval - (time.monotonic() - started)))
         finally:
             loop.run_until_complete(session.close())

--- a/src/py_inference_scheduler/datalayer/metrics/refresher.py
+++ b/src/py_inference_scheduler/datalayer/metrics/refresher.py
@@ -1,0 +1,110 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from collections.abc import Awaitable, Callable, Sequence
+
+import aiohttp
+
+from py_inference_scheduler.datalayer.metrics.datastore import InflightStore
+from py_inference_scheduler.framework import Endpoint
+
+logger = logging.getLogger(__name__)
+
+FetchMetrics = Callable[[Endpoint, InflightStore, aiohttp.ClientSession], Awaitable[None]]
+
+_REPORT_EVERY_S = 30.0
+
+
+class MetricsRefresher:
+    """Polls worker /metrics from a dedicated thread with a private event loop.
+
+    The serving loop cannot starve it (the thread waits on the GIL, not the
+    serving loop's ready queue), and its aiohttp session is loop-affine to the
+    private loop so no I/O marshals back to the serving loop. `staleness()`
+    exposes snapshot age so starvation is measured rather than assumed.
+    Endpoint updates are single reference assignments: readers see old or new
+    state, never torn.
+    """
+
+    def __init__(
+        self,
+        list_endpoints: Callable[[], Sequence[Endpoint]],
+        inflight: InflightStore,
+        fetch_metrics: FetchMetrics,
+        interval_ms: int = 100,
+    ) -> None:
+        self._list_endpoints = list_endpoints
+        self._inflight = inflight
+        self._fetch = fetch_metrics
+        self._interval = interval_ms / 1000.0
+        self._last_refresh = 0.0
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, name="metrics-refresher", daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def staleness(self) -> float:
+        return time.monotonic() - self._last_refresh if self._last_refresh else float("inf")
+
+    def _run(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        session = loop.run_until_complete(self._make_session())
+        last_report = 0.0
+        try:
+            while not self._stop.is_set():
+                started = time.monotonic()
+                endpoints = self._list_endpoints()
+                if endpoints:
+                    results = loop.run_until_complete(
+                        asyncio.gather(
+                            *[self._fetch(ep, self._inflight, session) for ep in endpoints],
+                            return_exceptions=True,
+                        )
+                    )
+                    failures = [r for r in results if isinstance(r, BaseException)]
+                    # staleness() must stay honest: only a successful fetch counts as fresh.
+                    if len(failures) < len(endpoints):
+                        self._last_refresh = time.monotonic()
+                    now = time.monotonic()
+                    if failures and now - last_report > _REPORT_EVERY_S:
+                        logger.warning(
+                            "metrics-refresher: %d/%d fetches failed (first: %r)",
+                            len(failures), len(endpoints), failures[0],
+                        )
+                        last_report = now
+                    elif now - last_report > _REPORT_EVERY_S:
+                        logger.info(
+                            "metrics-refresher: %d endpoints, scrape %.0fms, interval %.0fms",
+                            len(endpoints), (now - started) * 1000, self._interval * 1000,
+                        )
+                        last_report = now
+                self._stop.wait(max(0.0, self._interval - (time.monotonic() - started)))
+        finally:
+            loop.run_until_complete(session.close())
+            loop.close()
+
+    @staticmethod
+    async def _make_session() -> aiohttp.ClientSession:
+        return aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=2))

--- a/src/py_inference_scheduler/datalayer/metrics/refresher.py
+++ b/src/py_inference_scheduler/datalayer/metrics/refresher.py
@@ -62,7 +62,7 @@ class MetricsRefresher:
         self._stop.set()
 
     def staleness(self) -> float:
-        """ How old the last metrics poll was """
+        """How old the last metrics poll was."""
         return time.monotonic() - self._last_refresh if self._last_refresh else float("inf")
 
     def _run(self) -> None:

--- a/src/py_inference_scheduler/datalayer/metrics/refresher.py
+++ b/src/py_inference_scheduler/datalayer/metrics/refresher.py
@@ -33,14 +33,11 @@ _REPORT_EVERY_S = 30.0
 
 
 class MetricsRefresher:
-    """Polls worker /metrics from a dedicated thread with a private event loop.
+    """Keeps routing_stats fresh by polling worker metrics off the request path.
 
-    The serving loop cannot starve it (the thread waits on the GIL, not the
-    serving loop's ready queue), and its aiohttp session is loop-affine to the
-    private loop so no I/O marshals back to the serving loop. `staleness()`
-    exposes snapshot age so starvation is measured rather than assumed.
-    Endpoint updates are single reference assignments: readers see old or new
-    state, never torn.
+    Runs in its own thread with a private event loop, so a busy serving loop
+    can neither starve the polling nor receive any of its I/O. Updates are
+    atomic reference swaps; `staleness()` reports the snapshot's age.
     """
 
     def __init__(
@@ -65,6 +62,7 @@ class MetricsRefresher:
         self._stop.set()
 
     def staleness(self) -> float:
+        """ How old the last metrics poll was """
         return time.monotonic() - self._last_refresh if self._last_refresh else float("inf")
 
     def _run(self) -> None:
@@ -84,7 +82,6 @@ class MetricsRefresher:
                         )
                     )
                     failures = [r for r in results if isinstance(r, BaseException)]
-                    # staleness() must stay honest: only a successful fetch counts as fresh.
                     if len(failures) < len(endpoints):
                         self._last_refresh = time.monotonic()
                     now = time.monotonic()

--- a/tests/unit/datalayer/metrics/test_poller.py
+++ b/tests/unit/datalayer/metrics/test_poller.py
@@ -18,7 +18,7 @@ import itertools
 import time
 
 from py_inference_scheduler.datalayer.metrics.datastore import InflightStore
-from py_inference_scheduler.datalayer.metrics.refresher import MetricsRefresher
+from py_inference_scheduler.datalayer.metrics.poller import MetricsPoller
 from py_inference_scheduler.framework import Endpoint
 
 
@@ -46,32 +46,32 @@ def _failing_fetch():
 
 
 def test_staleness_is_infinite_before_first_fetch():
-    r = MetricsRefresher(list, InflightStore(), _counting_fetch(itertools.count()))
-    assert r.staleness() == float("inf")
+    p = MetricsPoller(list, InflightStore(), _counting_fetch(itertools.count()))
+    assert p.staleness() == float("inf")
 
 
 def test_refreshes_stats_and_becomes_fresh():
     ep = Endpoint(name="a", attributes={})
-    r = MetricsRefresher(
+    p = MetricsPoller(
         lambda: [ep], InflightStore(), _counting_fetch(itertools.count()), interval_ms=10
     )
-    r.start()
+    p.start()
     try:
         assert _wait_for(lambda: "routing_stats" in ep.attributes)
-        assert _wait_for(lambda: r.staleness() < 1.0)
+        assert _wait_for(lambda: p.staleness() < 1.0)
     finally:
-        r.stop()
+        p.stop()
 
 
 def test_all_failures_never_mark_fresh():
     ep = Endpoint(name="a", attributes={})
-    r = MetricsRefresher(lambda: [ep], InflightStore(), _failing_fetch(), interval_ms=10)
-    r.start()
+    p = MetricsPoller(lambda: [ep], InflightStore(), _failing_fetch(), interval_ms=10)
+    p.start()
     try:
         time.sleep(0.1)
-        assert r.staleness() == float("inf")
+        assert p.staleness() == float("inf")
     finally:
-        r.stop()
+        p.stop()
 
 
 def test_partial_failure_still_counts_as_fresh():
@@ -85,24 +85,24 @@ def test_partial_failure_still_counts_as_fresh():
         else:
             await counting(ep, inflight, session)
 
-    r = MetricsRefresher(lambda: [ok, bad], InflightStore(), fetch, interval_ms=10)
-    r.start()
+    p = MetricsPoller(lambda: [ok, bad], InflightStore(), fetch, interval_ms=10)
+    p.start()
     try:
-        assert _wait_for(lambda: r.staleness() < 1.0)
+        assert _wait_for(lambda: p.staleness() < 1.0)
         assert "routing_stats" not in bad.attributes
     finally:
-        r.stop()
+        p.stop()
 
 
 def test_stop_halts_polling():
     ep = Endpoint(name="a", attributes={})
-    r = MetricsRefresher(
+    p = MetricsPoller(
         lambda: [ep], InflightStore(), _counting_fetch(itertools.count()), interval_ms=10
     )
-    r.start()
+    p.start()
     assert _wait_for(lambda: ep.attributes.get("routing_stats"))
-    r.stop()
-    assert _wait_for(lambda: not r._thread.is_alive())
+    p.stop()
+    assert _wait_for(lambda: not p._thread.is_alive())
     tick = ep.attributes["routing_stats"]["tick"]
     time.sleep(0.05)
     assert ep.attributes["routing_stats"]["tick"] == tick
@@ -110,14 +110,14 @@ def test_stop_halts_polling():
 
 def test_new_endpoints_are_picked_up_between_cycles():
     eps: list[Endpoint] = [Endpoint(name="a", attributes={})]
-    r = MetricsRefresher(
+    p = MetricsPoller(
         lambda: list(eps), InflightStore(), _counting_fetch(itertools.count()), interval_ms=10
     )
-    r.start()
+    p.start()
     try:
         assert _wait_for(lambda: "routing_stats" in eps[0].attributes)
         late = Endpoint(name="late", attributes={})
         eps.append(late)
         assert _wait_for(lambda: "routing_stats" in late.attributes)
     finally:
-        r.stop()
+        p.stop()

--- a/tests/unit/datalayer/metrics/test_refresher.py
+++ b/tests/unit/datalayer/metrics/test_refresher.py
@@ -1,0 +1,123 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import itertools
+import time
+
+from py_inference_scheduler.datalayer.metrics.datastore import InflightStore
+from py_inference_scheduler.datalayer.metrics.refresher import MetricsRefresher
+from py_inference_scheduler.framework import Endpoint
+
+
+def _wait_for(cond, timeout: float = 3.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if cond():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def _counting_fetch(counter):
+    async def fetch(ep, inflight, session):
+        ep.attributes["routing_stats"] = {"tick": next(counter)}
+
+    return fetch
+
+
+def _failing_fetch():
+    async def fetch(ep, inflight, session):
+        raise RuntimeError("scrape failed")
+
+    return fetch
+
+
+def test_staleness_is_infinite_before_first_fetch():
+    r = MetricsRefresher(list, InflightStore(), _counting_fetch(itertools.count()))
+    assert r.staleness() == float("inf")
+
+
+def test_refreshes_stats_and_becomes_fresh():
+    ep = Endpoint(name="a", attributes={})
+    r = MetricsRefresher(
+        lambda: [ep], InflightStore(), _counting_fetch(itertools.count()), interval_ms=10
+    )
+    r.start()
+    try:
+        assert _wait_for(lambda: "routing_stats" in ep.attributes)
+        assert _wait_for(lambda: r.staleness() < 1.0)
+    finally:
+        r.stop()
+
+
+def test_all_failures_never_mark_fresh():
+    ep = Endpoint(name="a", attributes={})
+    r = MetricsRefresher(lambda: [ep], InflightStore(), _failing_fetch(), interval_ms=10)
+    r.start()
+    try:
+        time.sleep(0.1)
+        assert r.staleness() == float("inf")
+    finally:
+        r.stop()
+
+
+def test_partial_failure_still_counts_as_fresh():
+    ok, bad = Endpoint(name="ok", attributes={}), Endpoint(name="bad", attributes={})
+    counting = _counting_fetch(itertools.count())
+    failing = _failing_fetch()
+
+    async def fetch(ep, inflight, session):
+        if ep.name == "bad":
+            await failing(ep, inflight, session)
+        else:
+            await counting(ep, inflight, session)
+
+    r = MetricsRefresher(lambda: [ok, bad], InflightStore(), fetch, interval_ms=10)
+    r.start()
+    try:
+        assert _wait_for(lambda: r.staleness() < 1.0)
+        assert "routing_stats" not in bad.attributes
+    finally:
+        r.stop()
+
+
+def test_stop_halts_polling():
+    ep = Endpoint(name="a", attributes={})
+    r = MetricsRefresher(
+        lambda: [ep], InflightStore(), _counting_fetch(itertools.count()), interval_ms=10
+    )
+    r.start()
+    assert _wait_for(lambda: ep.attributes.get("routing_stats"))
+    r.stop()
+    assert _wait_for(lambda: not r._thread.is_alive())
+    tick = ep.attributes["routing_stats"]["tick"]
+    time.sleep(0.05)
+    assert ep.attributes["routing_stats"]["tick"] == tick
+
+
+def test_new_endpoints_are_picked_up_between_cycles():
+    eps: list[Endpoint] = [Endpoint(name="a", attributes={})]
+    r = MetricsRefresher(
+        lambda: list(eps), InflightStore(), _counting_fetch(itertools.count()), interval_ms=10
+    )
+    r.start()
+    try:
+        assert _wait_for(lambda: "routing_stats" in eps[0].attributes)
+        late = Endpoint(name="late", attributes={})
+        eps.append(late)
+        assert _wait_for(lambda: "routing_stats" in late.attributes)
+    finally:
+        r.stop()

--- a/tests/unit/integration/slime/test_server.py
+++ b/tests/unit/integration/slime/test_server.py
@@ -139,3 +139,11 @@ def test_generate_proxies_and_keeps_prefix_affinity():
         assert second.status_code == 200
         assert first.json()["worker"] in {"a", "b"}
         assert first.json()["worker"] == second.json()["worker"]
+
+
+def test_metrics_refresh_ms_flag_defaults_and_overrides():
+    from integration.slime.__main__ import _add_args, build_parser
+
+    parser = build_parser("d", "slime", add_args=_add_args)
+    assert parser.parse_args([]).metrics_refresh_ms == 100
+    assert parser.parse_args(["--metrics-refresh-ms", "250"]).metrics_refresh_ms == 250


### PR DESCRIPTION
Changed metrics fetching for the Slime integration from a scrape every time a request is being routed to a background poll every ```metrics-refresh-ms```. This was done to reduce routing overhead per request in Slime.  