### PR TITLE
Replace request-path print() with leveled logging

### DIFF
--- a/integration/slime/Miles_README.md
+++ b/integration/slime/Miles_README.md
@@ -53,6 +53,9 @@ python -m integration.slime --host 0.0.0.0 --port 8000
 
 It uses the bundled `examples/scheduler.yaml` by default; pass `--config /path/to/your.yaml` to
 override with a custom policy. You can also just change `examples/scheduler.yaml` as mentioned above.
+Set `RLS_DECISION_LOG=1` in the environment to log each request's per-endpoint stats at decision
+time. The line is formatted and written inside the scheduling call itself, so it adds routing
+latency on every request while enabled — leave it off for benchmarks.
 
 Then point miles at it — the **only** change to miles' launch is two flags (and leave
 `--use-miles-router` unset). Run `bash scripts/run-qwen3-4B.sh` as documented, adding two flags to

--- a/integration/slime/README.md
+++ b/integration/slime/README.md
@@ -72,6 +72,9 @@ python -m integration.slime --host 0.0.0.0 --port 8000 --metrics-refresh-ms 100
 
 It uses the bundled `examples/scheduler.yaml` by default; pass `--config /path/to/your.yaml` to
 override with a custom policy. The poll intervals for metrics is set by `--metrics-refresh-ms`(default is 100ms).
+Set `RLS_DECISION_LOG=1` in the environment to log each request's per-endpoint stats at decision
+time. The line is formatted and written inside the scheduling call itself, so it adds routing
+latency on every request while enabled — leave it off for benchmarks.
 
 Then point slime at it — the **only** change to slime's launch is two flags:
 

--- a/integration/slime/__main__.py
+++ b/integration/slime/__main__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import pathlib
 from collections.abc import Callable
 
@@ -77,6 +78,12 @@ def run(
         )
 
     logging.basicConfig(level=args.log_level.upper())
+    if os.environ.get("RLS_DECISION_LOG") == "1":
+        # per-request candidate stats without global DEBUG noise
+        # costs one formatted log line per request while enabled - not for benchmarking
+        from py_inference_scheduler.core.scheduler import decision_logger
+
+        decision_logger.setLevel(logging.DEBUG)
 
     with pathlib.Path(args.config).open(encoding="utf-8") as f:
         config_dict = yaml.safe_load(f)

--- a/src/py_inference_scheduler/core/scheduler.py
+++ b/src/py_inference_scheduler/core/scheduler.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import pathlib
 from typing import Sequence
@@ -32,6 +33,12 @@ from py_inference_scheduler.framework import (
     SchedulingResult,
     ScoredEndpoint,
 )
+
+logger = logging.getLogger(__name__)
+
+# Child logger: RLS_DECISION_LOG=1 logs per-request decision detail
+# Performance will DEGRADE with this on.
+decision_logger = logging.getLogger(__name__ + ".decisions")
 
 
 class Scheduler:
@@ -81,7 +88,7 @@ class Scheduler:
             return
         mtime = pathlib.Path(self.config_path).stat().st_mtime
         if mtime > self.last_mtime:
-            print(f"Reloading scheduler config from {self.config_path}")
+            logger.info("Reloading scheduler config from %s", self.config_path)
             with pathlib.Path(self.config_path).open(encoding="utf-8") as f:
                 config_dict = yaml.safe_load(f)
             if not isinstance(config_dict, dict):
@@ -91,38 +98,43 @@ class Scheduler:
             self.profiles = config.profiles
             self.last_mtime = mtime
 
-    def schedule(
-        self, request: LLMRequest, candidates: Sequence[Endpoint]
-    ) -> SchedulingResult:
+    def schedule(self, request: LLMRequest, candidates: Sequence[Endpoint]) -> SchedulingResult:
         self._maybe_reload_config()
         if not candidates:
             raise ValueError("no scheduling candidates provided")
+
+        # guard to prevent computation on request path when DEBUG not enabled
+        if decision_logger.isEnabledFor(logging.DEBUG):
+            decision_logger.debug(
+                "request %s candidates: %s",
+                request.request_id,
+                {
+                    e.name: {
+                        "queue_len": e.attributes.get("queue_len"),
+                        "stats": e.attributes.get("routing_stats"),
+                    }
+                    for e in candidates
+                },
+            )
 
         cycle_state = CycleState()
         profile_results: dict[str, ProfileRunResult | None] = {}
 
         # ask profile handler which profiles to run
-        selected = self.profile_handler.pick(
-            cycle_state, request, self.profiles, profile_results
-        )
+        selected = self.profile_handler.pick(cycle_state, request, self.profiles, profile_results)
         assert selected is not None  # noqa: S101
 
-        def run_profile(
-            profile_name: str, profile: SchedulerProfile
-        ) -> ProfileRunResult | None:
+        def run_profile(profile_name: str, profile: SchedulerProfile) -> ProfileRunResult | None:
             try:
                 return profile.run(request, cycle_state, candidates)
-            except Exception as e:  # noqa: BLE001
-                print(f"Error running profile {profile_name}: ")
-                print(repr(e))
+            except Exception:
+                logger.exception("Error running profile %s", profile_name)
                 return None
 
         for name, profile in selected.items():
             profile_results[name] = run_profile(name, profile)
 
-        primary = self.profile_handler.process_results(
-            cycle_state, request, profile_results
-        )
+        primary = self.profile_handler.process_results(cycle_state, request, profile_results)
 
         # Build SchedulingResult
         result = SchedulingResult(
@@ -135,28 +147,24 @@ class Scheduler:
             if primary is not None and primary in result.profile_results
             else []
         )
-        print(f"Selected endpoint {selected_eps}")
+        logger.debug("Selected endpoint %s", selected_eps)
         if selected_eps and primary is not None:
             for w in self.profiles[primary].scorers:
                 if hasattr(w.scorer, "pre_request"):
                     w.scorer.pre_request(cycle_state, request, selected_eps[0].endpoint)  # type: ignore[attr-defined]
         return result
 
-    def run(
-        self, request: LLMRequest, candidates: Sequence[Endpoint]
-    ) -> Sequence[ScoredEndpoint]:
+    def run(self, request: LLMRequest, candidates: Sequence[Endpoint]) -> Sequence[ScoredEndpoint]:
         scheduler_output = self.schedule(request, candidates)
         profile_name = scheduler_output.primary_profile_name
         profile_results = (
-            scheduler_output.profile_results.get(profile_name)
-            if profile_name is not None
-            else None
+            scheduler_output.profile_results.get(profile_name) if profile_name is not None else None
         )
 
-        print(f"Profile {profile_name} results: {profile_results}")
+        logger.debug("Profile %s results: %s", profile_name, profile_results)
         selected_endpoint = profile_results.endpoint_list[:1] if profile_results else []
 
         if len(selected_endpoint) > 0:
             return selected_endpoint  # pick top 1
-        print("No endpoint selected, defaulting to framework routing logic")
+        logger.debug("No endpoint selected, defaulting to framework routing logic")
         return []

--- a/src/py_inference_scheduler/datalayer/metrics/poller.py
+++ b/src/py_inference_scheduler/datalayer/metrics/poller.py
@@ -27,6 +27,7 @@ from py_inference_scheduler.framework import Endpoint
 
 logger = logging.getLogger(__name__)
 
+# Implementations must not raise: scrape errors belong in routing_stats["error"]
 FetchMetrics = Callable[[Endpoint, InflightStore, aiohttp.ClientSession], Awaitable[None]]
 
 _LOG_CADENCE = 300
@@ -40,7 +41,8 @@ class MetricsPoller:
 
     WARNING: the thread shares the GIL, so the poll must stay I/O-bound.
     CPU-bound work here can delay routing decisions.
-    staleness() returns the snapshot's age.
+    staleness() returns the age of the last poll cycle that got usable stats
+    from at least one endpoint.
     """
 
     def __init__(
@@ -79,26 +81,27 @@ class MetricsPoller:
                 started = time.monotonic()
                 endpoints = self._list_endpoints()
                 if endpoints:
-                    results = loop.run_until_complete(
-                        asyncio.gather(
-                            *[self._fetch(ep, self._inflight, session) for ep in endpoints],
-                            return_exceptions=True,
+                    try:
+                        loop.run_until_complete(
+                            asyncio.gather(*[
+                                self._fetch(ep, self._inflight, session) for ep in endpoints
+                            ])
                         )
-                    )
-                    failures = [r for r in results if isinstance(r, BaseException)]
-                    if len(failures) < len(endpoints):
-                        self._last_refresh = time.monotonic()
+                    except Exception:
+                        logger.exception("metrics-poller: fetch raised despite contract")
+                    # refresh only when at least one endpoint yielded usable stats
+                    for ep in endpoints:
+                        stats = ep.attributes.get("routing_stats")
+                        if isinstance(stats, dict) and stats.get("error") is None:
+                            self._last_refresh = time.monotonic()
+                            break
                     now = time.monotonic()
-                    if failures and now - last_log > log_interval:
-                        logger.warning(
-                            "metrics-poller: %d/%d fetches failed (first: %r)",
-                            len(failures), len(endpoints), failures[0],
-                        )
-                        last_log = now
-                    elif now - last_log > log_interval:
+                    if now - last_log > log_interval:
                         logger.info(
                             "metrics-poller: %d endpoints, scrape %.0fms, interval %.0fms",
-                            len(endpoints), (now - started) * 1000, self._interval * 1000,
+                            len(endpoints),
+                            (now - started) * 1000,
+                            self._interval * 1000,
                         )
                         last_log = now
                 self._stop.wait(max(0.0, self._interval - (time.monotonic() - started)))

--- a/src/py_inference_scheduler/framework/interface.py
+++ b/src/py_inference_scheduler/framework/interface.py
@@ -14,10 +14,13 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Mapping, Protocol, Sequence
 
 from .types import CycleState, Endpoint, LLMRequest, ProfileRunResult, ScoredEndpoint
+
+logger = logging.getLogger(__name__)
 
 
 class FilterPlugin(Protocol):
@@ -115,7 +118,9 @@ class SchedulerProfile:
         total_scores: dict[str, float] = dict.fromkeys(endpoints_map.keys(), 0.0)
         for w in self.scorers:
             raw_sc = w.scorer.score(cycle_state, request, endpoints_map)
-            print(f"Scorer {w.scorer} raw scores: {raw_sc}")
+            # guard: skips the call overhead on the request path when DEBUG is off
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("Scorer %s raw scores: %s", w.scorer, raw_sc)
             # normalize raw_sc values to [0,1] across endpoints present in endpoints_map
             vals = [float(raw_sc.get(name, 0.0)) for name in endpoints_map]
             if vals:
@@ -133,9 +138,7 @@ class SchedulerProfile:
 
         # create ScoredEndpoint list preserving endpoint info
         scored = [
-            ScoredEndpoint(
-                endpoint=endpoints_map[name], score=total_scores.get(name, 0.0)
-            )
+            ScoredEndpoint(endpoint=endpoints_map[name], score=total_scores.get(name, 0.0))
             for name in endpoints_map
         ]
         # sort descending

--- a/src/py_inference_scheduler/plugins/flow_control/kv_saturation.py
+++ b/src/py_inference_scheduler/plugins/flow_control/kv_saturation.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import Any, Sequence
 
@@ -23,6 +24,8 @@ from py_inference_scheduler.framework import (
     LLMRequest,
     register_flow_control,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @register_flow_control("kv_saturation")
@@ -79,7 +82,9 @@ class KVSaturationPlugin(FlowControlPlugin):
                 physical_kv = routing_stats.get("kv", 1.0)  # type: ignore[attr-defined]
                 if physical_kv < drip_threshold_kv:
                     self._last_drip_at = now
-                    print(f"[BUDGET] Drip Admission to {c.name} (Physical KV: {physical_kv:.2f})")
+                    logger.debug(
+                        "[BUDGET] Drip Admission to %s (Physical KV: %.2f)", c.name, physical_kv
+                    )
                     return [c]
         return []
 
@@ -100,9 +105,11 @@ class KVSaturationPlugin(FlowControlPlugin):
             tokens_required,
         )
         self._budgeted_requests.add(request.request_id)
-        print(
-            f"[BUDGET] Admission committed for req={request.request_id} to replica={selected.name} "
-            f"(New Usage: {self._replica_token_usage[selected.name]})"
+        logger.debug(
+            "[BUDGET] Admission committed for req=%s to replica=%s (New Usage: %s)",
+            request.request_id,
+            selected.name,
+            self._replica_token_usage[selected.name],
         )
 
     def release(self, request: LLMRequest, endpoint_name: str) -> None:
@@ -112,9 +119,11 @@ class KVSaturationPlugin(FlowControlPlugin):
                 0,
                 self._replica_token_usage.get(replica_id_to_reclaim, 0) - tokens,
             )
-            print(
-                f"[BUDGET] Released req={request.request_id} from replica={replica_id_to_reclaim} "
-                f"(New Usage: {self._replica_token_usage[replica_id_to_reclaim]})"
+            logger.debug(
+                "[BUDGET] Released req=%s from replica=%s (New Usage: %s)",
+                request.request_id,
+                replica_id_to_reclaim,
+                self._replica_token_usage[replica_id_to_reclaim],
             )
             self._budgeted_requests.discard(request.request_id)
 
@@ -123,7 +132,9 @@ class KVSaturationPlugin(FlowControlPlugin):
             "isl": isl,
             "osl": osl,
         }
-        print(f"[BUDGET] Learned stats for rollout={rollout_request_id}: ISL={isl}, OSL={osl}")
+        logger.debug(
+            "[BUDGET] Learned stats for rollout=%s: ISL=%d, OSL=%d", rollout_request_id, isl, osl
+        )
 
     def _get_rollout_request_id(self, body: Any) -> tuple[str, int]:  # noqa: ANN401
         import struct
@@ -163,7 +174,7 @@ class KVSaturationPlugin(FlowControlPlugin):
                 )
 
         except Exception as e:  # noqa: BLE001
-            print(f"[PLUGIN ERROR] Failed to parse request ID securely: {e}")
+            logger.warning("Failed to parse request ID securely: %s", e)
 
         return "", 0
 

--- a/src/py_inference_scheduler/plugins/scorers/prefix_plugin.py
+++ b/src/py_inference_scheduler/plugins/scorers/prefix_plugin.py
@@ -16,10 +16,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from collections import OrderedDict
 from typing import Mapping, Sequence, cast
 
 from py_inference_scheduler.framework import CycleState, Endpoint, LLMRequest, register_scorer
+
+logger = logging.getLogger(__name__)
 
 
 class PrefixIndexer:
@@ -90,7 +93,7 @@ def _get_user_input_bytes(body: object) -> bytes | None:
     try:
         return json.dumps(body, separators=(",", ":")).encode("utf-8")
     except Exception:  # noqa: BLE001
-        print("Unable to serialize body to bytes for prefix hashing")
+        logger.warning("Unable to serialize body to bytes for prefix hashing")
         return None
 
 
@@ -189,9 +192,7 @@ class PrefixCacheScorer:
         if len(scores) == 0 or max_score < (total * self.min_match_ratio):
             for name in pods:
                 scores[name] = 0.0
-            min_count = min(
-                len(self.indexer._server_to_hashes.get(name, {})) for name in pods
-            )
+            min_count = min(len(self.indexer._server_to_hashes.get(name, {})) for name in pods)
             for name in pods:
                 if len(self.indexer._server_to_hashes.get(name, {})) == min_count:
                     scores[name] = 1.0
@@ -209,7 +210,7 @@ class PrefixCacheScorer:
         if hashes is not None:
             self.add_prefixes_for_server(selected_endpoint.name, cast(Sequence[int], hashes))
         else:
-            print("Warning: prefix_hashes not found in cycle_state in pre_request")
+            logger.warning("prefix_hashes not found in cycle_state in pre_request")
             body_bytes = _get_user_input_bytes(request.body)
             hashes = _hash_prompt_bytes(
                 request.target_model,

--- a/tests/unit/datalayer/metrics/test_poller.py
+++ b/tests/unit/datalayer/metrics/test_poller.py
@@ -63,12 +63,42 @@ def test_refreshes_stats_and_becomes_fresh():
         p.stop()
 
 
-def test_all_failures_never_mark_fresh():
+def test_raising_fetch_keeps_polling_but_stays_stale(caplog):
+    # fetch callables must not raise. If one does, the poller logs the
+    # contract violation and keeps polling, but the metrics stay stale
+    calls = itertools.count(1)
+    attempts = [0]
+
+    async def fetch(ep, inflight, session):
+        attempts[0] = next(calls)
+        raise RuntimeError("scrape failed")
+
     ep = Endpoint(name="a", attributes={})
-    p = MetricsPoller(lambda: [ep], InflightStore(), _failing_fetch(), interval_ms=10)
+    p = MetricsPoller(lambda: [ep], InflightStore(), fetch, interval_ms=10)
     p.start()
     try:
-        time.sleep(0.1)
+        assert _wait_for(lambda: attempts[0] >= 3)
+        assert p.staleness() == float("inf")
+        assert any("despite contract" in r.message for r in caplog.records)
+    finally:
+        p.stop()
+
+
+def test_all_soft_errors_stay_stale():
+    # contract-compliant failure: fetch records the error and returns;
+    # cycles where every endpoint errored must not refresh staleness
+    calls = itertools.count(1)
+    attempts = [0]
+
+    async def fetch(ep, inflight, session):
+        attempts[0] = next(calls)
+        ep.attributes["routing_stats"] = {"error": "HTTP error 503"}
+
+    ep = Endpoint(name="a", attributes={})
+    p = MetricsPoller(lambda: [ep], InflightStore(), fetch, interval_ms=10)
+    p.start()
+    try:
+        assert _wait_for(lambda: attempts[0] >= 3)
         assert p.staleness() == float("inf")
     finally:
         p.stop()


### PR DESCRIPTION
## Problem

- The vllm-router fork embeds this scheduler in-process via PyO3.
- Every routing decision runs on a Rust thread while holding the GIL. 
- Any `print()` on that path is synchronous stdout I/O inside the GIL. 
- Prints also can't be turned off, so the cost is unconditional.

## Changes

- All request-path `print()`s (scheduler, scorer normalization, kv_saturation and prefix plugins) become leveled logging: per-request detail at DEBUG, lifecycle at INFO, error paths at WARNING/EXCEPTION with tracebacks.
- Opt-in `RLS_DECISION_LOG=1` logs each request's per-endpoint stats at decision time without global DEBUG. Documented in the slime/miles READMEs with the explicit caveat that it adds routing latency while enabled.
- Poller: `staleness()` now refreshes only when at least one endpoint scraped cleanly, so all-error cycles (dead workers, engine sleeps) read as stale.

This is in preparation for the ```vllm-router-integration``` with our scheduler.