### PR TITLE
vllm-router integration: external-policy adapter for the Rust router fork

### DIFF
--- a/integration/slime/Miles_README.md
+++ b/integration/slime/Miles_README.md
@@ -53,6 +53,9 @@ python -m integration.slime --host 0.0.0.0 --port 8000
 
 It uses the bundled `examples/scheduler.yaml` by default; pass `--config /path/to/your.yaml` to
 override with a custom policy. You can also just change `examples/scheduler.yaml` as mentioned above.
+Set `RLS_DECISION_LOG=1` in the environment to log each request's per-endpoint stats at decision
+time. The line is formatted and written inside the scheduling call itself, so it adds routing
+latency on every request while enabled — leave it off for benchmarks.
 
 Then point miles at it — the **only** change to miles' launch is two flags (and leave
 `--use-miles-router` unset). Run `bash scripts/run-qwen3-4B.sh` as documented, adding two flags to

--- a/integration/slime/README.md
+++ b/integration/slime/README.md
@@ -72,6 +72,9 @@ python -m integration.slime --host 0.0.0.0 --port 8000 --metrics-refresh-ms 100
 
 It uses the bundled `examples/scheduler.yaml` by default; pass `--config /path/to/your.yaml` to
 override with a custom policy. The poll intervals for metrics is set by `--metrics-refresh-ms`(default is 100ms).
+Set `RLS_DECISION_LOG=1` in the environment to log each request's per-endpoint stats at decision
+time. The line is formatted and written inside the scheduling call itself, so it adds routing
+latency on every request while enabled — leave it off for benchmarks.
 
 Then point slime at it — the **only** change to slime's launch is two flags:
 

--- a/integration/slime/__main__.py
+++ b/integration/slime/__main__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import pathlib
 from collections.abc import Callable
 
@@ -77,6 +78,12 @@ def run(
         )
 
     logging.basicConfig(level=args.log_level.upper())
+    if os.environ.get("RLS_DECISION_LOG") == "1":
+        # per-request candidate stats without global DEBUG noise
+        # costs one formatted log line per request while enabled - not for benchmarking
+        from py_inference_scheduler.core.scheduler import decision_logger
+
+        decision_logger.setLevel(logging.DEBUG)
 
     with pathlib.Path(args.config).open(encoding="utf-8") as f:
         config_dict = yaml.safe_load(f)

--- a/integration/vllm_router/README.md
+++ b/integration/vllm_router/README.md
@@ -1,0 +1,96 @@
+# vllm-router Integration with py-inference-scheduler
+
+## Compatibility Notice
+
+**This integration is designed for [our vllm-router fork](https://github.com/aniketmohanty82/router/tree/external-policy)**
+(branch `external-policy`, based on [vllm-router v0.1.15](https://github.com/vllm-project/router/releases/tag/v0.1.15)),
+validated against vLLM 0.23.0 engines. Stock vllm-router has no external-policy hook — the fork is required.
+
+## Architecture
+
+vllm-router is the vLLM ecosystem's Rust router. Our fork adds an external-policy hook: at launch,
+`--external-policy-factory` imports a factory and calls it once to obtain a selection callable; on every
+request the router calls `select(workers, request_text, headers)` on a Rust thread and routes to the
+returned worker index. `None` or any exception falls back to a built-in policy
+(`--external-fallback-policy`, default `round_robin`) — the scheduler can never fail a request. Engine
+metrics are scraped off the request path by the shared `MetricsPoller`; router-side inflight counts arrive
+with each call in the worker dicts. The router keeps full ownership of serving (streaming, retries,
+circuit breakers, worker management); we only decide which worker serves each request.
+
+Key components:
+- [adapter.py](./adapter.py): bridges the callable contract to `Scheduler` — lazy worker registry,
+  metrics polling, index mapping.
+- [factory.py](./factory.py): the target of `--external-policy-factory`; builds the `Scheduler` and
+  returns `adapter.select`.
+- [`__main__.py`](./__main__.py): the `python -m integration.vllm_router` launcher.
+
+---
+
+## Prerequisites (Step 1)
+
+Build and install the fork into the same environment as this repo (the Rust extension needs a Rust
+toolchain, and builds against the Python it is installed with):
+
+```bash
+git clone -b external-policy https://github.com/aniketmohanty82/router.git
+cd router
+pip install .
+```
+
+> [!NOTE]
+> The build compiles the Rust extension silently for several minutes — this is normal.
+
+## Integration Configuration (Step 2)
+
+The routing policy reuses slime's [`examples/scheduler.yaml`](../slime/examples/scheduler.yaml) (the scorers
+are engine-agnostic). Edit that file directly to customize, or pass
+`--external-scheduler-config /path/to/your.yaml`. See the
+[Scheduler Customization Guide](../../docs/scheduler_customization.md).
+
+## Running the Router (Step 3)
+
+Clone this repo and install the scheduler (editable, without its heavyweight optional deps) alongside
+the fork from Step 1:
+
+```bash
+git clone https://github.com/llm-d-incubation/py-inference-scheduler.git
+cd py-inference-scheduler
+pip install -e . --no-deps
+pip install aiohttp prometheus-client pyyaml setproctitle
+```
+
+**Start the router** — run from the repo root. `--external-scheduler-config` is ours; every other flag is
+forwarded to vllm-router unchanged (worker discovery, PD flags, timeouts — see `vllm-router --help`):
+
+```bash
+python -m integration.vllm_router \
+  --external-scheduler-config integration/slime/examples/scheduler.yaml \
+  --worker-urls http://worker1:8000 http://worker2:8000 \
+  --host 0.0.0.0 --port 30000
+```
+
+Workers may also register at runtime through the router's `POST /workers` API; the adapter tracks whatever
+worker set the router offers per request. The `/metrics` poll interval is set by
+`--external-metrics-interval-ms` (default 100ms).
+
+What the router expects of each worker: it health-gates on `GET /health` **before serving** (it blocks up
+to 600s waiting for all `--worker-urls` to answer), scrapes Prometheus text from `GET /metrics` — the
+scorers read `vllm:num_requests_waiting`, `vllm:num_requests_running`, and `vllm:kv_cache_usage_perc`
+(missing gauges are treated as zero) — and proxies the inference endpoints (`/v1/completions`,
+`/v1/chat/completions`, `/generate`, ...). Real vLLM servers provide all of this out of the box.
+Note the router renames its process to `vllm::router` (setproctitle), so match that name with
+`pkill`/`pgrep`, not `python`.
+
+Set `RLS_DECISION_LOG=1` in the environment to log each request's per-endpoint stats at decision
+time. The line is formatted and written inside the scheduling call itself, so it adds routing
+latency on every request while enabled — leave it off for benchmarks.
+
+## Verifying Results (Step 4)
+
+The router prints to **stdout** — the terminal where you started it in Step 3. On startup, watch for the
+scheduler config loading, the fork assigning registered workers to us (`Assigning policy external`), and
+the adapter picking workers up: `Seeded worker <url>` for the startup `--worker-urls` set,
+`Tracking worker <url>` for workers registered later via `POST /workers`.
+
+Routing decisions are visible with `RLS_DECISION_LOG=1` (each request's per-endpoint stats at decision
+time) or `--log-level debug` (per-scorer raw scores and the selected endpoint for every request).

--- a/integration/vllm_router/__init__.py
+++ b/integration/vllm_router/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from integration.vllm_router.adapter import VllmRouterSchedulerAdapter
+from integration.vllm_router.factory import make_policy
+
+__all__ = ["VllmRouterSchedulerAdapter", "make_policy"]

--- a/integration/vllm_router/__main__.py
+++ b/integration/vllm_router/__main__.py
@@ -1,0 +1,77 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+
+from integration.vllm_router.factory import ENV_CONFIG, ENV_METRICS_INTERVAL_MS
+
+FACTORY_SPEC = "integration.vllm_router.factory:make_policy"
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="vllm-router driven by the rl-scheduler (external policy)",
+        epilog="All other arguments are forwarded to vllm-router; see `vllm-router --help`.",
+    )
+    parser.add_argument(
+        "--external-scheduler-config",
+        required=True,
+        help="path to the scheduler yaml config",
+    )
+    parser.add_argument(
+        "--external-metrics-interval-ms",
+        type=int,
+        default=100,
+        help="worker /metrics polling interval for the MetricsPoller",
+    )
+    parser.add_argument("--log-level", default="info", help="python-side log level")
+    args, router_argv = parser.parse_known_args(argv)
+
+    # timestamps matter here: adapter/poller lines interleave with the Rust
+    # router's own timestamped log and phase correlation depends on them
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s.%(msecs)03d %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    if os.environ.get("RLS_DECISION_LOG") == "1":
+        # per-request candidate stats without global DEBUG noise; costs one
+        # formatted log line per request while enabled - not for benchmarking
+        from py_inference_scheduler.core.scheduler import decision_logger
+
+        decision_logger.setLevel(logging.DEBUG)
+    os.environ[ENV_CONFIG] = args.external_scheduler_config
+    os.environ[ENV_METRICS_INTERVAL_MS] = str(args.external_metrics_interval_ms)
+
+    try:
+        from vllm_router.launch_router import launch_router, parse_router_args
+    except ImportError as e:
+        raise SystemExit(
+            "vllm-router (the Rust router fork) is not installed in this environment; "
+            "install its wheel into the venv first"
+        ) from e
+
+    router_args = parse_router_args(router_argv)
+    router_args.external_policy_factory = FACTORY_SPEC
+    if router_args.external_fallback_policy is None:
+        router_args.external_fallback_policy = "round_robin"
+    launch_router(router_args)
+
+
+if __name__ == "__main__":
+    main()

--- a/integration/vllm_router/adapter.py
+++ b/integration/vllm_router/adapter.py
@@ -1,0 +1,201 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any, Sequence
+from uuid import uuid4
+
+from py_inference_scheduler.core.scheduler import Scheduler
+from py_inference_scheduler.datalayer.metrics.datastore import InflightStore
+from py_inference_scheduler.datalayer.metrics.poller import FetchMetrics, MetricsPoller
+from py_inference_scheduler.datalayer.metrics.vime.vllm import fetch_worker_metrics
+from py_inference_scheduler.framework import Endpoint, LLMRequest
+
+logger = logging.getLogger(__name__)
+
+
+class _RouterLoadView(InflightStore):
+    """Inflight counts sourced from the router's own per-worker load counters.
+
+    The vllm-router fork tracks inflight requests itself (increment at
+    selection, decrement at stream end), so instead of bookkeeping our own
+    InflightStore we mirror the loads it hands us on every select() call.
+    increment/decrement stay unused no-ops from the parent.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._loads: dict[str, int] = {}
+        self._loads_lock = threading.Lock()
+
+    def merge(self, loads: dict[str, int]) -> None:
+        with self._loads_lock:
+            self._loads.update(loads)
+
+    def prune(self, urls: Sequence[str]) -> None:
+        with self._loads_lock:
+            for url in urls:
+                self._loads.pop(url, None)
+
+    def get(self, endpoint_name: str) -> int:
+        with self._loads_lock:
+            return self._loads.get(endpoint_name, 0)
+
+    def get_all(self) -> dict[str, int]:
+        with self._loads_lock:
+            return dict(self._loads)
+
+
+class VllmRouterSchedulerAdapter:
+    """Bridges the vllm-router fork's external-policy callable to Scheduler.
+
+    The router calls select() from multiple tokio threads while holding the
+    GIL; the adapter lock serializes decisions because scheduler plugins are
+    not thread-safe (the GIL alone does not make multi-step selection atomic).
+    Workers register with the router, not with us, so the Endpoint registry
+    is built lazily from the worker dicts of each call and TTL-pruned.
+    """
+
+    def __init__(
+        self,
+        scheduler: Scheduler,
+        *,
+        metrics_interval_ms: int = 100,
+        endpoint_ttl_s: float = 60.0,
+        fetch_metrics: FetchMetrics = fetch_worker_metrics,
+    ) -> None:
+        self._scheduler = scheduler
+        self._lock = threading.Lock()
+        self._endpoints: dict[str, Endpoint] = {}
+        self._last_seen: dict[str, float] = {}
+        self._ttl = endpoint_ttl_s
+        self._loads = _RouterLoadView()
+        self._poller = MetricsPoller(
+            self.list_endpoints, self._loads, fetch_metrics, interval_ms=metrics_interval_ms
+        )
+
+    def start(self) -> None:
+        self._poller.start()
+
+    def stop(self) -> None:
+        self._poller.stop()
+
+    def staleness(self) -> float:
+        return self._poller.staleness()
+
+    def list_endpoints(self) -> list[Endpoint]:
+        with self._lock:
+            return list(self._endpoints.values())
+
+    def seed_workers(self, urls: Sequence[str]) -> None:
+        """Pre-register statically known workers for the poller.
+
+        Without this, requests in the first poll interval of a cold boot are
+        scheduled on empty stats. Unreachable seeds age out via TTL.
+        """
+        now = time.monotonic()
+        with self._lock:
+            for url in urls:
+                if url not in self._endpoints:
+                    self._endpoints[url] = Endpoint(
+                        name=url,
+                        attributes={
+                            "url": url,
+                            "worker_type": "regular",
+                            "queue_len": 0,
+                            "routing_stats": {},
+                        },
+                    )
+                    self._last_seen[url] = now
+                    logger.info("Seeded worker %s", url)
+
+    def select(
+        self,
+        workers: Sequence[dict[str, Any]],
+        request_text: str | None,
+        headers: dict[str, str] | None,
+    ) -> int | None:
+        """External-policy callable: index into workers, or None for fallback.
+
+        Never raises: any failure defers to the router's built-in fallback.
+        """
+        if not workers:
+            return None
+        try:
+            with self._lock:
+                candidates = self._sync_endpoints(workers)
+                request = LLMRequest(
+                    request_id=uuid4().hex,
+                    target_model=str(workers[0].get("model_id") or "") or None,
+                    headers=headers or {},
+                    body=request_text,
+                )
+                scored = self._scheduler.run(request, candidates)
+        except Exception:
+            logger.exception("Selection failed, deferring to router fallback")
+            return None
+        if not scored:
+            return None
+        winner_url = scored[0].endpoint.name
+        for idx, worker in enumerate(workers):
+            if worker["url"] == winner_url:
+                return idx
+        logger.warning("Winner %s not in offered worker set", winner_url)
+        return None
+
+    def _sync_endpoints(self, workers: Sequence[dict[str, Any]]) -> list[Endpoint]:
+        """Upsert endpoints from this call's worker dicts; prune the unseen.
+
+        queue_len is written here from the router's load counter and kept
+        fresh between requests by the poller via _RouterLoadView.
+        """
+        now = time.monotonic()
+        loads: dict[str, int] = {}
+        candidates: list[Endpoint] = []
+        for worker in workers:
+            url = str(worker["url"])
+            load = int(worker.get("load") or 0)
+            loads[url] = load
+            endpoint = self._endpoints.get(url)
+            if endpoint is None:
+                endpoint = Endpoint(
+                    name=url,
+                    attributes={
+                        "url": url,
+                        "worker_type": str(worker.get("worker_type") or "regular"),
+                        "queue_len": 0,
+                        "routing_stats": {},
+                    },
+                )
+                self._endpoints[url] = endpoint
+                logger.info("Tracking worker %s", url)
+            endpoint.attributes["queue_len"] = load
+            self._last_seen[url] = now
+            candidates.append(endpoint)
+        self._loads.merge(loads)
+        # TTL substitutes for the deregistration signal we no longer get:
+        # the router just stops offering removed workers, and without expiry
+        # the poller would scrape dead URLs forever
+        expired = [url for url, seen in self._last_seen.items() if now - seen > self._ttl]
+        for url in expired:
+            self._endpoints.pop(url, None)
+            self._last_seen.pop(url, None)
+            logger.info("Dropping worker %s (unseen for %.0fs)", url, self._ttl)
+        if expired:
+            self._loads.prune(expired)
+        return candidates

--- a/integration/vllm_router/factory.py
+++ b/integration/vllm_router/factory.py
@@ -1,0 +1,66 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import os
+import pathlib
+from collections.abc import Callable
+
+import yaml
+
+from integration.vllm_router.adapter import VllmRouterSchedulerAdapter
+from py_inference_scheduler import Scheduler
+from py_inference_scheduler.core.config import SchedulerConfig
+
+logger = logging.getLogger(__name__)
+
+ENV_CONFIG = "ROUTER_CONFIG_PATH"
+ENV_METRICS_INTERVAL_MS = "RLS_METRICS_INTERVAL_MS"
+
+# Keeps running adapters reachable (poller stop, staleness introspection)
+_live_adapters: list[VllmRouterSchedulerAdapter] = []
+
+
+def make_policy(router_args: object = None) -> Callable:
+    """Target of vllm-router's --external-policy-factory flag.
+
+    Configuration arrives via env rather than router_args so the fork needs
+    no scheduler-specific flags: ROUTER_CONFIG_PATH (scheduler.yaml, required)
+    and RLS_METRICS_INTERVAL_MS (poller interval, default 100).
+    Raises on missing/invalid config: launch must fail closed, the router's
+    fallback policy is reserved for per-request failures.
+    """
+    config_path = os.environ.get(ENV_CONFIG)
+    if not config_path:
+        raise ValueError(f"{ENV_CONFIG} must point to a scheduler yaml config")
+    with pathlib.Path(config_path).open(encoding="utf-8") as f:
+        config_dict = yaml.safe_load(f)
+    if not isinstance(config_dict, dict):
+        raise TypeError("Parsed configuration is not a valid dictionary.")
+    config = SchedulerConfig.from_dict(config_dict)
+    logger.info("Loaded scheduler config: %s", config)
+
+    interval_ms = int(os.environ.get(ENV_METRICS_INTERVAL_MS, "100"))
+    adapter = VllmRouterSchedulerAdapter(
+        Scheduler.new_with_config(config), metrics_interval_ms=interval_ms
+    )
+    static_urls = getattr(router_args, "worker_urls", None)
+    if static_urls:
+        adapter.seed_workers([str(u) for u in static_urls])
+    adapter.start()
+
+    _live_adapters.append(adapter)
+    return adapter.select

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,15 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
 
-# Skip following imports for third-party packages whose source uses Python 3.10+ syntax. 
+# Skip following imports for third-party packages whose source uses Python 3.10+ syntax.
 [[tool.mypy.overrides]]
 module = ["pytest.*", "ray.*"]
 follow_imports = "skip"
+
+# The vllm-router fork wheel is only installed in deployment venvs, not in CI.
+[[tool.mypy.overrides]]
+module = ["vllm_router.*"]
+ignore_missing_imports = true
 
 [tool.ruff]
 target-version = "py38"

--- a/src/py_inference_scheduler/core/scheduler.py
+++ b/src/py_inference_scheduler/core/scheduler.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import pathlib
 from typing import Sequence
@@ -32,6 +33,12 @@ from py_inference_scheduler.framework import (
     SchedulingResult,
     ScoredEndpoint,
 )
+
+logger = logging.getLogger(__name__)
+
+# Child logger: RLS_DECISION_LOG=1 logs per-request decision detail
+# Performance will DEGRADE with this on.
+decision_logger = logging.getLogger(__name__ + ".decisions")
 
 
 class Scheduler:
@@ -81,7 +88,7 @@ class Scheduler:
             return
         mtime = pathlib.Path(self.config_path).stat().st_mtime
         if mtime > self.last_mtime:
-            print(f"Reloading scheduler config from {self.config_path}")
+            logger.info("Reloading scheduler config from %s", self.config_path)
             with pathlib.Path(self.config_path).open(encoding="utf-8") as f:
                 config_dict = yaml.safe_load(f)
             if not isinstance(config_dict, dict):
@@ -91,38 +98,43 @@ class Scheduler:
             self.profiles = config.profiles
             self.last_mtime = mtime
 
-    def schedule(
-        self, request: LLMRequest, candidates: Sequence[Endpoint]
-    ) -> SchedulingResult:
+    def schedule(self, request: LLMRequest, candidates: Sequence[Endpoint]) -> SchedulingResult:
         self._maybe_reload_config()
         if not candidates:
             raise ValueError("no scheduling candidates provided")
+
+        # guard to prevent computation on request path when DEBUG not enabled
+        if decision_logger.isEnabledFor(logging.DEBUG):
+            decision_logger.debug(
+                "request %s candidates: %s",
+                request.request_id,
+                {
+                    e.name: {
+                        "queue_len": e.attributes.get("queue_len"),
+                        "stats": e.attributes.get("routing_stats"),
+                    }
+                    for e in candidates
+                },
+            )
 
         cycle_state = CycleState()
         profile_results: dict[str, ProfileRunResult | None] = {}
 
         # ask profile handler which profiles to run
-        selected = self.profile_handler.pick(
-            cycle_state, request, self.profiles, profile_results
-        )
+        selected = self.profile_handler.pick(cycle_state, request, self.profiles, profile_results)
         assert selected is not None  # noqa: S101
 
-        def run_profile(
-            profile_name: str, profile: SchedulerProfile
-        ) -> ProfileRunResult | None:
+        def run_profile(profile_name: str, profile: SchedulerProfile) -> ProfileRunResult | None:
             try:
                 return profile.run(request, cycle_state, candidates)
-            except Exception as e:  # noqa: BLE001
-                print(f"Error running profile {profile_name}: ")
-                print(repr(e))
+            except Exception:
+                logger.exception("Error running profile %s", profile_name)
                 return None
 
         for name, profile in selected.items():
             profile_results[name] = run_profile(name, profile)
 
-        primary = self.profile_handler.process_results(
-            cycle_state, request, profile_results
-        )
+        primary = self.profile_handler.process_results(cycle_state, request, profile_results)
 
         # Build SchedulingResult
         result = SchedulingResult(
@@ -135,28 +147,24 @@ class Scheduler:
             if primary is not None and primary in result.profile_results
             else []
         )
-        print(f"Selected endpoint {selected_eps}")
+        logger.debug("Selected endpoint %s", selected_eps)
         if selected_eps and primary is not None:
             for w in self.profiles[primary].scorers:
                 if hasattr(w.scorer, "pre_request"):
                     w.scorer.pre_request(cycle_state, request, selected_eps[0].endpoint)  # type: ignore[attr-defined]
         return result
 
-    def run(
-        self, request: LLMRequest, candidates: Sequence[Endpoint]
-    ) -> Sequence[ScoredEndpoint]:
+    def run(self, request: LLMRequest, candidates: Sequence[Endpoint]) -> Sequence[ScoredEndpoint]:
         scheduler_output = self.schedule(request, candidates)
         profile_name = scheduler_output.primary_profile_name
         profile_results = (
-            scheduler_output.profile_results.get(profile_name)
-            if profile_name is not None
-            else None
+            scheduler_output.profile_results.get(profile_name) if profile_name is not None else None
         )
 
-        print(f"Profile {profile_name} results: {profile_results}")
+        logger.debug("Profile %s results: %s", profile_name, profile_results)
         selected_endpoint = profile_results.endpoint_list[:1] if profile_results else []
 
         if len(selected_endpoint) > 0:
             return selected_endpoint  # pick top 1
-        print("No endpoint selected, defaulting to framework routing logic")
+        logger.debug("No endpoint selected, defaulting to framework routing logic")
         return []

--- a/src/py_inference_scheduler/datalayer/metrics/poller.py
+++ b/src/py_inference_scheduler/datalayer/metrics/poller.py
@@ -27,6 +27,7 @@ from py_inference_scheduler.framework import Endpoint
 
 logger = logging.getLogger(__name__)
 
+# Implementations must not raise: scrape errors belong in routing_stats["error"]
 FetchMetrics = Callable[[Endpoint, InflightStore, aiohttp.ClientSession], Awaitable[None]]
 
 _LOG_CADENCE = 300
@@ -40,7 +41,8 @@ class MetricsPoller:
 
     WARNING: the thread shares the GIL, so the poll must stay I/O-bound.
     CPU-bound work here can delay routing decisions.
-    staleness() returns the snapshot's age.
+    staleness() returns the age of the last poll cycle that got usable stats
+    from at least one endpoint.
     """
 
     def __init__(
@@ -79,26 +81,27 @@ class MetricsPoller:
                 started = time.monotonic()
                 endpoints = self._list_endpoints()
                 if endpoints:
-                    results = loop.run_until_complete(
-                        asyncio.gather(
-                            *[self._fetch(ep, self._inflight, session) for ep in endpoints],
-                            return_exceptions=True,
+                    try:
+                        loop.run_until_complete(
+                            asyncio.gather(*[
+                                self._fetch(ep, self._inflight, session) for ep in endpoints
+                            ])
                         )
-                    )
-                    failures = [r for r in results if isinstance(r, BaseException)]
-                    if len(failures) < len(endpoints):
-                        self._last_refresh = time.monotonic()
+                    except Exception:
+                        logger.exception("metrics-poller: fetch raised despite contract")
+                    # refresh only when at least one endpoint yielded usable stats
+                    for ep in endpoints:
+                        stats = ep.attributes.get("routing_stats")
+                        if isinstance(stats, dict) and stats.get("error") is None:
+                            self._last_refresh = time.monotonic()
+                            break
                     now = time.monotonic()
-                    if failures and now - last_log > log_interval:
-                        logger.warning(
-                            "metrics-poller: %d/%d fetches failed (first: %r)",
-                            len(failures), len(endpoints), failures[0],
-                        )
-                        last_log = now
-                    elif now - last_log > log_interval:
+                    if now - last_log > log_interval:
                         logger.info(
                             "metrics-poller: %d endpoints, scrape %.0fms, interval %.0fms",
-                            len(endpoints), (now - started) * 1000, self._interval * 1000,
+                            len(endpoints),
+                            (now - started) * 1000,
+                            self._interval * 1000,
                         )
                         last_log = now
                 self._stop.wait(max(0.0, self._interval - (time.monotonic() - started)))

--- a/src/py_inference_scheduler/framework/interface.py
+++ b/src/py_inference_scheduler/framework/interface.py
@@ -14,10 +14,13 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Mapping, Protocol, Sequence
 
 from .types import CycleState, Endpoint, LLMRequest, ProfileRunResult, ScoredEndpoint
+
+logger = logging.getLogger(__name__)
 
 
 class FilterPlugin(Protocol):
@@ -115,7 +118,9 @@ class SchedulerProfile:
         total_scores: dict[str, float] = dict.fromkeys(endpoints_map.keys(), 0.0)
         for w in self.scorers:
             raw_sc = w.scorer.score(cycle_state, request, endpoints_map)
-            print(f"Scorer {w.scorer} raw scores: {raw_sc}")
+            # guard: skips the call overhead on the request path when DEBUG is off
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("Scorer %s raw scores: %s", w.scorer, raw_sc)
             # normalize raw_sc values to [0,1] across endpoints present in endpoints_map
             vals = [float(raw_sc.get(name, 0.0)) for name in endpoints_map]
             if vals:
@@ -133,9 +138,7 @@ class SchedulerProfile:
 
         # create ScoredEndpoint list preserving endpoint info
         scored = [
-            ScoredEndpoint(
-                endpoint=endpoints_map[name], score=total_scores.get(name, 0.0)
-            )
+            ScoredEndpoint(endpoint=endpoints_map[name], score=total_scores.get(name, 0.0))
             for name in endpoints_map
         ]
         # sort descending

--- a/src/py_inference_scheduler/plugins/flow_control/kv_saturation.py
+++ b/src/py_inference_scheduler/plugins/flow_control/kv_saturation.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from typing import Any, Sequence
 
@@ -23,6 +24,8 @@ from py_inference_scheduler.framework import (
     LLMRequest,
     register_flow_control,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @register_flow_control("kv_saturation")
@@ -79,7 +82,9 @@ class KVSaturationPlugin(FlowControlPlugin):
                 physical_kv = routing_stats.get("kv", 1.0)  # type: ignore[attr-defined]
                 if physical_kv < drip_threshold_kv:
                     self._last_drip_at = now
-                    print(f"[BUDGET] Drip Admission to {c.name} (Physical KV: {physical_kv:.2f})")
+                    logger.debug(
+                        "[BUDGET] Drip Admission to %s (Physical KV: %.2f)", c.name, physical_kv
+                    )
                     return [c]
         return []
 
@@ -100,9 +105,11 @@ class KVSaturationPlugin(FlowControlPlugin):
             tokens_required,
         )
         self._budgeted_requests.add(request.request_id)
-        print(
-            f"[BUDGET] Admission committed for req={request.request_id} to replica={selected.name} "
-            f"(New Usage: {self._replica_token_usage[selected.name]})"
+        logger.debug(
+            "[BUDGET] Admission committed for req=%s to replica=%s (New Usage: %s)",
+            request.request_id,
+            selected.name,
+            self._replica_token_usage[selected.name],
         )
 
     def release(self, request: LLMRequest, endpoint_name: str) -> None:
@@ -112,9 +119,11 @@ class KVSaturationPlugin(FlowControlPlugin):
                 0,
                 self._replica_token_usage.get(replica_id_to_reclaim, 0) - tokens,
             )
-            print(
-                f"[BUDGET] Released req={request.request_id} from replica={replica_id_to_reclaim} "
-                f"(New Usage: {self._replica_token_usage[replica_id_to_reclaim]})"
+            logger.debug(
+                "[BUDGET] Released req=%s from replica=%s (New Usage: %s)",
+                request.request_id,
+                replica_id_to_reclaim,
+                self._replica_token_usage[replica_id_to_reclaim],
             )
             self._budgeted_requests.discard(request.request_id)
 
@@ -123,7 +132,9 @@ class KVSaturationPlugin(FlowControlPlugin):
             "isl": isl,
             "osl": osl,
         }
-        print(f"[BUDGET] Learned stats for rollout={rollout_request_id}: ISL={isl}, OSL={osl}")
+        logger.debug(
+            "[BUDGET] Learned stats for rollout=%s: ISL=%d, OSL=%d", rollout_request_id, isl, osl
+        )
 
     def _get_rollout_request_id(self, body: Any) -> tuple[str, int]:  # noqa: ANN401
         import struct
@@ -163,7 +174,7 @@ class KVSaturationPlugin(FlowControlPlugin):
                 )
 
         except Exception as e:  # noqa: BLE001
-            print(f"[PLUGIN ERROR] Failed to parse request ID securely: {e}")
+            logger.warning("Failed to parse request ID securely: %s", e)
 
         return "", 0
 

--- a/src/py_inference_scheduler/plugins/scorers/prefix_plugin.py
+++ b/src/py_inference_scheduler/plugins/scorers/prefix_plugin.py
@@ -16,10 +16,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from collections import OrderedDict
 from typing import Mapping, Sequence, cast
 
 from py_inference_scheduler.framework import CycleState, Endpoint, LLMRequest, register_scorer
+
+logger = logging.getLogger(__name__)
 
 
 class PrefixIndexer:
@@ -90,7 +93,7 @@ def _get_user_input_bytes(body: object) -> bytes | None:
     try:
         return json.dumps(body, separators=(",", ":")).encode("utf-8")
     except Exception:  # noqa: BLE001
-        print("Unable to serialize body to bytes for prefix hashing")
+        logger.warning("Unable to serialize body to bytes for prefix hashing")
         return None
 
 
@@ -189,9 +192,7 @@ class PrefixCacheScorer:
         if len(scores) == 0 or max_score < (total * self.min_match_ratio):
             for name in pods:
                 scores[name] = 0.0
-            min_count = min(
-                len(self.indexer._server_to_hashes.get(name, {})) for name in pods
-            )
+            min_count = min(len(self.indexer._server_to_hashes.get(name, {})) for name in pods)
             for name in pods:
                 if len(self.indexer._server_to_hashes.get(name, {})) == min_count:
                     scores[name] = 1.0
@@ -209,7 +210,7 @@ class PrefixCacheScorer:
         if hashes is not None:
             self.add_prefixes_for_server(selected_endpoint.name, cast(Sequence[int], hashes))
         else:
-            print("Warning: prefix_hashes not found in cycle_state in pre_request")
+            logger.warning("prefix_hashes not found in cycle_state in pre_request")
             body_bytes = _get_user_input_bytes(request.body)
             hashes = _hash_prompt_bytes(
                 request.target_model,

--- a/tests/unit/datalayer/metrics/test_poller.py
+++ b/tests/unit/datalayer/metrics/test_poller.py
@@ -63,12 +63,42 @@ def test_refreshes_stats_and_becomes_fresh():
         p.stop()
 
 
-def test_all_failures_never_mark_fresh():
+def test_raising_fetch_keeps_polling_but_stays_stale(caplog):
+    # fetch callables must not raise. If one does, the poller logs the
+    # contract violation and keeps polling, but the metrics stay stale
+    calls = itertools.count(1)
+    attempts = [0]
+
+    async def fetch(ep, inflight, session):
+        attempts[0] = next(calls)
+        raise RuntimeError("scrape failed")
+
     ep = Endpoint(name="a", attributes={})
-    p = MetricsPoller(lambda: [ep], InflightStore(), _failing_fetch(), interval_ms=10)
+    p = MetricsPoller(lambda: [ep], InflightStore(), fetch, interval_ms=10)
     p.start()
     try:
-        time.sleep(0.1)
+        assert _wait_for(lambda: attempts[0] >= 3)
+        assert p.staleness() == float("inf")
+        assert any("despite contract" in r.message for r in caplog.records)
+    finally:
+        p.stop()
+
+
+def test_all_soft_errors_stay_stale():
+    # contract-compliant failure: fetch records the error and returns;
+    # cycles where every endpoint errored must not refresh staleness
+    calls = itertools.count(1)
+    attempts = [0]
+
+    async def fetch(ep, inflight, session):
+        attempts[0] = next(calls)
+        ep.attributes["routing_stats"] = {"error": "HTTP error 503"}
+
+    ep = Endpoint(name="a", attributes={})
+    p = MetricsPoller(lambda: [ep], InflightStore(), fetch, interval_ms=10)
+    p.start()
+    try:
+        assert _wait_for(lambda: attempts[0] >= 3)
         assert p.staleness() == float("inf")
     finally:
         p.stop()


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #54** — this branch includes #54's three logging commits until it merges; **review only the last commit** (`integration: vllm-router external-policy adapter`). Once #54 lands, this branch will be rebased onto main and the diff collapses to that single commit.

## What

Standalone integration for teams that route with [vllm-router](https://github.com/vllm-project/router): our [fork](https://github.com/aniketmohanty82/router/tree/external-policy) (based on v0.1.15) adds an `--external-policy-factory` hook, and this package plugs the repo's `Scheduler` into it. Per request, the router calls `select(workers, request_text, headers)` in-process (PyO3) and routes to the returned index; `None` or any exception falls back to a built-in policy — the scheduler can never fail a request.

- `adapter.py` — URL-keyed lazy worker registry with TTL, `queue_len` sourced from the router's own inflight counters, engine gauges via the shared `MetricsPoller` off the request path, headers into `LLMRequest` (sticky_session-capable).
- `factory.py` — the factory the fork imports; fail-closed config loading.
- `__main__.py` — `python -m integration.vllm_router` launcher; unknown flags forward to vllm-router.
- README follows the slime/vime integration format and was validated by a context-free cold run (build fork → run router → verified scheduler decisions end-to-end).
- `pyproject.toml`: mypy override for the fork wheel (installed in deployment venvs, not CI).

## Why it depends on #54

The launcher's `RLS_DECISION_LOG` toggle imports the `decision_logger` #54 introduces, and the fork's request path runs the scheduler under the GIL on Rust threads — #54's print→logging conversion is what makes per-request overhead acceptable there (measured: select p95 6.3ms → 0.93ms).

## Validation

On 8×H100 (reports in the branch history / benchmark logs): 4-arm synthetic A/B and a vime real-RL A/B both put the integration's mechanical overhead below run-to-run noise vs stock round_robin; correctness validated end-to-end with vime driving the fork via only its two router flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)