### PR TITLE
Fix SchedulerConfig.from_dict mutating the caller's config dict

### DIFF
--- a/src/py_inference_scheduler/core/config.py
+++ b/src/py_inference_scheduler/core/config.py
@@ -58,13 +58,13 @@ class SchedulerConfig:
                 "Scheduler configuration must include a 'profile_handler' "
                 "dictionary with a 'type' key."
             )
-
-        ph_type = ph_config.pop("type")
-        profile_handler = build_profile_handler(ph_type, **ph_config)
-
         profiles_dict = config_dict.get("profiles")
         if not profiles_dict:
             raise ValueError("Scheduler configuration must include a 'profiles' dictionary.")
+
+        ph_cfg = dict(ph_config)
+        ph_type = ph_cfg.pop("type")
+        profile_handler = build_profile_handler(ph_type, **ph_cfg)
 
         parsed_profiles: dict[str, SchedulerProfile] = {}
         for profile_name, prof_data in profiles_dict.items():


### PR DESCRIPTION
 The profile_handler branch popped `type` in place, unlike the filter/scorer/picker which copy first