### PR TITLE
Mooncake KV offload tier: deployment config examples

### DIFF
--- a/configs/mooncake/client-config.yaml
+++ b/configs/mooncake/client-config.yaml
@@ -1,0 +1,42 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Per-replica Mooncake Store client config, mounted into each vLLM worker at
+# MOONCAKE_CONFIG_PATH (/etc/mooncake/mooncake_config.json). Read by the vLLM
+# MooncakeStoreConnector (worker.py MooncakeStoreConfig.from_file).
+#
+#   mode=embedded         : each rank contributes global_segment_size to the pool.
+#   protocol=rdma         : use the ConnectX-7 RoCE fabric (MC_FORCE_HCA=1 in the
+#                           engine env makes this fail-fast rather than silent TCP).
+#   metadata_server=P2PHANDSHAKE : peers handshake directly; no separate metadata
+#                           service needed (master handles allocation/eviction).
+#   device_name=""        : auto-detect the RDMA verbs device claimed via DRA.
+#
+# TODO(tune): size global_segment_size to the per-replica KV working set.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mooncake-config
+  namespace: default
+data:
+  mooncake_config.json: |
+    {
+      "mode": "embedded",
+      "metadata_server": "P2PHANDSHAKE",
+      "master_server_address": "mooncake-master.default.svc.cluster.local:50051",
+      "protocol": "rdma",
+      "device_name": "",
+      "global_segment_size": "32gb",
+      "local_buffer_size": "4gb"
+    }

--- a/configs/mooncake/master.yaml
+++ b/configs/mooncake/master.yaml
@@ -1,0 +1,100 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mooncake Store master (control-plane only; never on the data path).
+# One per cluster. Owns membership, allocation, and the lease/eviction policy.
+# vLLM replicas connect to it at master_server_address (see client-config.yaml).
+#
+# Runs the SAME image as the Ray Serve workers (configs/mooncake/worker.Dockerfile)
+# with the command overridden to mooncake_master — one artifact, and the master
+# and every replica client are guaranteed the same mooncake wheel. Cost: a large
+# one-time image pull onto the CPU node. If that ever matters, the light
+# alternative is a dedicated image (python:3.12-slim + the same pinned
+# mooncake-transfer-engine wheel) kept in version lockstep manually.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mooncake-master
+  namespace: default
+  labels:
+    app: mooncake-master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mooncake-master
+  template:
+    metadata:
+      labels:
+        app: mooncake-master
+    spec:
+      # Control-plane only: schedule on the CPU/default pool, not the GPU nodes.
+      nodeSelector:
+        cloud.google.com/gke-nodepool: default-pool
+      containers:
+      - name: mooncake-master
+        image: <your-registry>/ray-llm-mooncake:2.56.0  # REPLACE: build from worker.Dockerfile
+        imagePullPolicy: Always
+        command: ["mooncake_master"]
+        args:
+        - "--port"
+        - "50051"
+        - "--enable_http_metadata_server"
+        - "--http_metadata_server_port"
+        - "8080"
+        # Touch-lease must outlive the slowest KV batch transfer or reads die
+        # mid-flight with LEASE_EXPIRED (-707) and vllm fails the request
+        # (proven under concurrent load on the tcp testbed; upstream's 5s is
+        # sized for rdma-speed handoffs). 60s covers congested-tcp batches;
+        # harmless for rdma. Part 2's advisor supersedes this with pinning.
+        - "--default_kv_lease_ttl"
+        - "60000"
+        ports:
+        - containerPort: 50051
+          name: rpc
+        - containerPort: 8080
+          name: metadata
+        - containerPort: 9003
+          name: metrics
+        # Sized to fit the default-pool's e2-medium nodes (~0.9 CPU allocatable).
+        # The master is control-plane only (never on the data path); bump these
+        # if you move it to a larger pool.
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+          limits:
+            cpu: "500m"
+            memory: "1Gi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mooncake-master
+  namespace: default
+  labels:
+    app: mooncake-master
+spec:
+  selector:
+    app: mooncake-master
+  ports:
+  - name: rpc
+    port: 50051
+    targetPort: 50051
+  - name: metadata
+    port: 8080
+    targetPort: 8080
+  - name: metrics
+    port: 9003
+    targetPort: 9003

--- a/configs/mooncake/ray-service.yaml
+++ b/configs/mooncake/ray-service.yaml
@@ -1,0 +1,196 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# RayService for the Mooncake shared-KV-tier validation on gke-gpu-rdma-cluster
+# (us-south1, 3x a3-ultragpu-8g, DRANET RDMA). This is the opt-in variant of
+# configs/ray_service.yaml: tp=2 workers that each claim 2 GPUs + 2 ConnectX-7
+# RDMA VFs, with ENABLE_MOONCAKE_KV=1 so datalayer/connectors/mooncake/kv.py
+# wires the DecodeKVSavingConnector into each replica.
+#
+# Apply order:
+#   kubectl apply -f configs/mooncake/client-config.yaml  # client ConfigMap
+#   kubectl apply -f configs/mooncake/master.yaml         # store master
+#   kubectl apply -f configs/mooncake/ray-service.yaml    # this file (RayService
+#                                     + the DRA ResourceClaimTemplate, below)
+#
+# Before applying:
+#   - IMAGE: build/push configs/mooncake/worker.Dockerfile (ray 2.56.0 + vllm
+#     0.22.0 base with the pinned mooncake wheel).
+#   - WORKING_DIR: push the mooncake-store branch so the zip below resolves.
+#   - Requires the KubeRay operator on the cluster (no rayservice CRD today):
+#     helm install kuberay-operator kuberay/kuberay-operator
+
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: ray-serve-llm-mooncake
+spec:
+  serveConfigV2: |
+    applications:
+      - name: llm-app
+        import_path: integration.rayserve.router:app
+        runtime_env:
+          # REPLACE: a zip of this repository at the commit you deploy
+          working_dir: "https://github.com/<your-fork>/py-inference-scheduler/archive/refs/heads/<branch>.zip"
+          env_vars:
+            # The single operator switch for the shared KV tier. Everything
+            # else the tier needs (PYTHONHASHSEED, MC_FORCE_HCA, ...) is a
+            # fixed constant in src/py_inference_scheduler/datalayer/
+            # connectors/mooncake/kv.py, injected into the engine runtime_env
+            # by the router. MOONCAKE_CONFIG_PATH may be set here to override
+            # its default (/etc/mooncake/mooncake_config.json).
+            ENABLE_MOONCAKE_KV: "1"
+            # Push/pull relocation (requires the tier above): any engine-side
+            # abort is completed as a continuation on another replica. Nothing
+            # aborts on its own - a trigger (e.g. Part 2 preemption rescue)
+            # supplies the aborts. Optional: MOONCAKE_RELOCATION_REGISTRY_CAP
+            # (default 4096) sizes the router's push-id -> replica memory; it
+            # must exceed requests routed between a push and its pull.
+            ENABLE_MOONCAKE_RELOCATION: "1"
+  rayClusterConfig:
+    rayVersion: "2.56.0"
+    headGroupSpec:
+      rayStartParams:
+        num-cpus: "0"
+        num-gpus: "0"
+        dashboard-host: "0.0.0.0"
+      template:
+        spec:
+          # The default-pool is e2-medium (~0.9 CPU allocatable); the head fits
+          # there only with small requests. For load tests move the head to the
+          # GPU pool (add the nvidia.com/gpu toleration) - a3-ultra nodes have
+          # 224 vCPU of headroom.
+          containers:
+          - name: ray-head
+            image: <your-registry>/ray-llm-mooncake:2.56.0  # REPLACE: build from worker.Dockerfile
+            imagePullPolicy: Always
+            ports:
+            - containerPort: 8000
+              name: serve
+            - containerPort: 6379
+              name: gcs
+            - containerPort: 8265
+              name: dashboard
+            env:
+            - name: RAY_SERVE_DEFAULT_HTTP_HOST
+              value: "0.0.0.0"
+            - name: ROUTER_CONFIG_PATH
+              value: "/etc/scheduler/scheduler.yaml"
+            resources:
+              limits:
+                cpu: "900m"
+                memory: "3Gi"
+              requests:
+                cpu: "900m"
+                memory: "3Gi"
+            volumeMounts:
+            - mountPath: /tmp/ray
+              name: ray-tmp
+            - mountPath: /etc/scheduler
+              name: scheduler-vol
+          volumes:
+          - name: ray-tmp
+            emptyDir: {}
+          - name: scheduler-vol
+            configMap:
+              name: scheduler-config
+    workerGroupSpecs:
+    - replicas: 3
+      minReplicas: 3
+      maxReplicas: 3
+      numOfHosts: 1
+      groupName: gpu-group
+      rayStartParams:
+        num-gpus: "2"
+      template:
+        spec:
+          nodeSelector:
+            cloud.google.com/gke-nodepool: rdma-gpu-pool  # REPLACE: your GPU node pool
+          # Hard-spread the 3 workers across the 3 GPU nodes so validation
+          # exercises inter-node RDMA, not NIC loopback. Relax to preferred (or
+          # drop) when scaling past one replica per node (e.g. replicas: 12).
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    ray.io/group: gpu-group
+                topologyKey: kubernetes.io/hostname
+          resourceClaims:
+          - name: rdma
+            resourceClaimTemplateName: mooncake-rdma
+          containers:
+          - name: ray-worker
+            image: <your-registry>/ray-llm-mooncake:2.56.0  # REPLACE: build from worker.Dockerfile
+            imagePullPolicy: Always
+            securityContext:
+              capabilities:
+                add: ["IPC_LOCK"]   # verbs memory pinning for RDMA
+            env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-secret
+                  key: hf_api_token
+            - name: RAY_SERVE_DEFAULT_HTTP_HOST
+              value: "0.0.0.0"
+            - name: ROUTER_CONFIG_PATH
+              value: "/etc/scheduler/scheduler.yaml"
+            resources:
+              limits:
+                cpu: "32"
+                memory: "128Gi"
+                nvidia.com/gpu: "2"
+              requests:
+                cpu: "32"
+                memory: "128Gi"
+                nvidia.com/gpu: "2"
+              claims:
+              - name: rdma
+            volumeMounts:
+            - mountPath: /tmp/ray
+              name: ray-tmp
+            - mountPath: /etc/scheduler
+              name: scheduler-vol
+            - mountPath: /etc/mooncake
+              name: mooncake-vol
+          volumes:
+          - name: ray-tmp
+            emptyDir: {}
+          - name: scheduler-vol
+            configMap:
+              name: scheduler-config
+          - name: mooncake-vol
+            configMap:
+              name: mooncake-config
+---
+# DRA claim template: each vLLM worker pod claims 2 of the node's 8 ConnectX-7
+# RDMA VFs (matched by the mrdma.google.com DeviceClass: dra.net devices with
+# rdma==true). count=2 pairs with tensor_parallel_size=2, so up to 4 workers can
+# share one 8-GPU / 8-NIC node. The worker pod references this via
+# spec.resourceClaims (see the worker-group snippet).
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: mooncake-rdma
+  namespace: default
+spec:
+  spec:
+    devices:
+      requests:
+      - name: rdma
+        exactly:
+          deviceClassName: mrdma.google.com
+          allocationMode: ExactCount
+          count: 2

--- a/configs/mooncake/worker.Dockerfile
+++ b/configs/mooncake/worker.Dockerfile
@@ -1,0 +1,54 @@
+# Copyright 2026 llm-d
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Image for the Mooncake shared KV tier (Ray Serve workers AND the store master).
+#
+# ray-llm 2.56.0 bakes vllm 0.22.0, which ships the multi-file mooncake/store
+# connector (introduced in vLLM 0.21.0), and its ray.llm imports match that
+# vllm's layout — pairing verified locally (full-stack imports + connector test
+# suite green). So the only addition is the Mooncake wheel, pinned so the
+# master and every replica client run the same version.
+#
+# The SAME image runs the mooncake master (configs/mooncake/master.yaml just
+# overrides the command with mooncake_master) — one artifact, zero
+# master/client version skew.
+#
+# Build + push (from the repo root):
+#   docker build -f configs/mooncake/worker.Dockerfile \
+#     -t <your-registry>/ray-llm-mooncake:2.56.0 .
+#   docker push <your-registry>/ray-llm-mooncake:2.56.0
+
+FROM rayproject/ray-llm:2.56.0-py312-cu130
+
+# mooncake_master and the RDMA transfer engine link against libnuma at runtime.
+RUN sudo apt-get update \
+    && sudo apt-get install -y --no-install-recommends libnuma1 \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+RUN uv pip install --system --no-cache-dir "mooncake-transfer-engine==0.3.11.post1"
+
+# The mooncake wheel links the CUDA 12 runtime; this cu130 image only ships
+# CUDA 13's. Install cu12's and register it with the loader (libcuda.so.1
+# itself is injected by GKE at run time, so it can't be checked at build).
+RUN uv pip install --system --no-cache-dir nvidia-cuda-runtime-cu12 \
+    && echo /home/ray/anaconda3/lib/python3.12/site-packages/nvidia/cuda_runtime/lib \
+       | sudo tee /etc/ld.so.conf.d/nvidia-cu12-runtime.conf \
+    && sudo ldconfig
+
+# Sanity: connector imports, cu12 runtime resolves, master binary starts.
+RUN python -c "import vllm, ray, ctypes; \
+    from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.store.connector import MooncakeStoreConnector; \
+    ctypes.CDLL('libcudart.so.12'); \
+    print('image OK: ray', ray.__version__, '/ vllm', vllm.__version__)" \
+    && (mooncake_master --help > /dev/null 2>&1 || [ $? -ne 127 ])


### PR DESCRIPTION
Deployment examples for the Mooncake shared-KV tier — the missing operational piece alongside #46/#47/#48 (which carry the library code but nothing deployable).

| File | What it is |
|---|---|
| `configs/mooncake/worker.Dockerfile` | Single image for Ray Serve workers AND the store master (ray-llm 2.56.0 / vllm 0.22.0 + pinned mooncake wheel). Bakes the two runtime fixes a fresh build rediscovers the hard way: `libnuma1` (mooncake_master crashes on load without it) and `nvidia-cuda-runtime-cu12` + ldconfig (the cu130 base ships only `libcudart.so.13`). |
| `configs/mooncake/master.yaml` | Store master Deployment (control-plane only, one per cluster) with the load-tested flags: HTTP metadata server on 8080, `--default_kv_lease_ttl 60000`. Same image as the workers — zero master/client version skew. |
| `configs/mooncake/client-config.yaml` | Per-replica store client ConfigMap: embedded mode, RDMA protocol, P2PHANDSHAKE, auto device detection via DRA. |
| `configs/mooncake/ray-service.yaml` | Opt-in RayService variant: tp=2 workers each claiming 2 GPUs + 2 RDMA VFs (DRANET ResourceClaimTemplate included), `ENABLE_MOONCAKE_KV=1` wiring the connectors from #46. |

Placeholder-marked (`<your-registry>`, code zip, node pool) — these are examples, not a turnkey deploy.

Values match the manifests validated on the RDMA cluster (3/3 tier checks 2026-07-07, RDMA A/B 2026-07-21), with one sizing note for review: the example uses `global_segment_size: 32gb`; later high-pressure runs (32B model, 128-wide rollouts) needed 96gb per replica to avoid store-full stalls. It's workload-dependent — flagging rather than baking in the larger default.

Draft pending decision on merge order with #46–#48 (this PR is independent of them code-wise; it only references env flags they introduce).

🤖 Generated with [Claude Code](https://claude.com/claude-code)